### PR TITLE
Add `cargo test` in CI workflow, fix failing Rustdoc examples

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,3 +24,6 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: build
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test

--- a/src/components/modal.rs
+++ b/src/components/modal.rs
@@ -235,32 +235,143 @@ pub struct ModalCloseMsg(pub String);
 /// use yew::agent::Dispatcher;
 /// use yew::prelude::*;
 /// // .. snip ..
+/// # use ybc::{Button, ModalCloser, ModalCloseMsg, ModalCard};
+/// #
+/// # #[derive(Properties, Clone, PartialEq)]
+/// # struct MyComponentProps {}
+/// #
+/// # struct MyComponent {
+/// #   link: ComponentLink<Self>,
+/// #   props: MyComponentProps,
+/// #   bridge: Dispatcher<ModalCloser>,
+/// # }
+/// #
+/// # impl Component for MyComponent {
+/// #   type Properties = MyComponentProps;
+/// #   type Message = ModalCloseMsg;
+/// #
 /// fn create(props: Self::Properties, link: ComponentLink<Self>) -> Self {
 ///     let bridge = ModalCloser::dispatcher();
-///     Self{link, props, bridge}
+///     Self { link, props, bridge }
 /// }
+/// #
+/// # fn update(&mut self, msg: Self::Message) -> ShouldRender {
+/// #     self.bridge.send(msg);
+/// #     true
+/// # }
+/// #
+/// # fn change(&mut self, props: Self::Properties) -> ShouldRender { false }
+/// #
+/// # fn view(&self) -> Html {
+/// # let closer = self.link.callback(|_| ModalCloseMsg("modal-0".into()));
+/// # html! {
+/// # <ModalCard
+/// #     id="modal-0"
+/// #     title="modal-title"
+/// #     // ... snip ...
+/// #     footer=html! {
+/// #         <Button onclick=closer>{ "Close" }</Button>
+/// #     }
+/// # />
+/// # }
+/// # }
+/// # }
 /// ```
 ///
 /// Next, in your component's `view` method, setup a callback to handle your component's close event.
 /// ```rust
+/// # use yew::agent::Dispatcher;
+/// # use yew::prelude::*;
+/// # use ybc::{Button, ModalCloser, ModalCloseMsg, ModalCard};
+/// #
+/// # #[derive(Properties, Clone, PartialEq)]
+/// # struct MyComponentProps {}
+/// #
+/// # struct MyComponent {
+/// #   link: ComponentLink<Self>,
+/// #   props: MyComponentProps,
+/// #   bridge: Dispatcher<ModalCloser>,
+/// # }
+/// #
+/// # impl Component for MyComponent {
+/// #   type Properties = MyComponentProps;
+/// #   type Message = ModalCloseMsg;
+/// #
+/// # fn create(props: Self::Properties, link: ComponentLink<Self>) -> Self {
+/// #     let bridge = ModalCloser::dispatcher();
+/// #     Self { link, props, bridge }
+/// # }
+/// #
+/// # fn update(&mut self, msg: Self::Message) -> ShouldRender {
+/// #     self.bridge.send(msg);
+/// #     true
+/// # }
+/// #
+/// # fn change(&mut self, props: Self::Properties) -> ShouldRender { false }
+/// #
+/// # fn view(&self) -> Html {
 /// let closer = self.link.callback(|_| ModalCloseMsg("modal-0".into()));
 /// // ... snip ...
+/// # html! {
 /// <ModalCard
 ///     id="modal-0"
+///     title="modal-title"
 ///     // ... snip ...
-///     footer=html!{
-///         <Button onclick=Some(closer)>{"Close"}</Button>
+///     footer=html! {
+///         <Button onclick=closer>{ "Close" }</Button>
 ///     }
 /// />
+/// # }
+/// # }
+/// # }
 /// ```
 ///
 /// Finally, in your component's `update` method, send the `ModalCloseMsg` over to the agent which
 /// will forward the message to the modal to cause it to close.
 /// ```rust
+/// # use yew::agent::Dispatcher;
+/// # use yew::prelude::*;
+/// # use ybc::{Button, ModalCloser, ModalCloseMsg, ModalCard};
+/// #
+/// # #[derive(Properties, Clone, PartialEq)]
+/// # struct MyComponentProps {}
+/// #
+/// # struct MyComponent {
+/// #   link: ComponentLink<Self>,
+/// #   props: MyComponentProps,
+/// #   bridge: Dispatcher<ModalCloser>,
+/// # }
+/// #
+/// # impl Component for MyComponent {
+/// #   type Properties = MyComponentProps;
+/// #   type Message = ModalCloseMsg;
+/// #
+/// # fn create(props: Self::Properties, link: ComponentLink<Self>) -> Self {
+/// #     let bridge = ModalCloser::dispatcher();
+/// #     Self { link, props, bridge }
+/// # }
+/// #
 /// fn update(&mut self, msg: Self::Message) -> ShouldRender {
 ///     self.bridge.send(msg);
 ///     true
 /// }
+/// #
+/// # fn change(&mut self, props: Self::Properties) -> ShouldRender { false }
+/// #
+/// # fn view(&self) -> Html {
+/// # let closer = self.link.callback(|_| ModalCloseMsg("modal-0".into()));
+/// # html! {
+/// # <ModalCard
+/// #     id="modal-0"
+/// #     title="modal-title"
+/// #     // ... snip ...
+/// #     footer=html! {
+/// #         <Button onclick=closer>{ "Close" }</Button>
+/// #     }
+/// # />
+/// # }
+/// # }
+/// # }
 /// ```
 ///
 /// This pattern allows you to communicate with a modal by its given ID, allowing


### PR DESCRIPTION
Current CI workflow does not perform any testing on the codebase - which in fact does not include any unit or integration tests.
The lack of testing lowers the confidence users might have in the library, and makes upgrading dependencies complex as impact of such upgrades (ex: breaking changes) can't be identified easily.

This PR aims to try improving this, by having `cargo test` in the CI workflow, and fixing existing Rustdoc examples that are currently failing after such addition.