### PR TITLE
update ybc to yew 0.19

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,11 @@ keywords = ["wasm", "web", "bulma", "sass", "yew"]
 [dependencies]
 derive_more = "0.99.9"
 web-sys = { version="0.3", features=["Element", "File", "HtmlCollection", "HtmlSelectElement"] }
-yew = { version="0.18.0", features=["web_sys"] }
-yewtil = { version="0.4.0", features=["neq"] }
-yew-router = { version="0.15.0", features=["web_sys"], optional=true }
+yew = { git="https://github.com/yewstack/yew.git" }
+yew-agent = { git="https://github.com/yewstack/yew.git" }
+yew-router = { git="https://github.com/yewstack/yew.git", optional=true }
+wasm-bindgen = "0.2"
+serde = "1"
 
 [features]
 default = ["router"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["wasm", "web-programming"]
 keywords = ["wasm", "web", "bulma", "sass", "yew"]
 
 [dependencies]
-derive_more = "0.99.9"
+derive_more = { version="0.99.9", default-features=false, features=["display"] }
 web-sys = { version="0.3", features=["Element", "File", "HtmlCollection", "HtmlSelectElement"] }
 yew = { git="https://github.com/yewstack/yew.git" }
 yew-agent = { git="https://github.com/yewstack/yew.git" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,9 @@ keywords = ["wasm", "web", "bulma", "sass", "yew"]
 [dependencies]
 derive_more = { version="0.99.9", default-features=false, features=["display"] }
 web-sys = { version="0.3", features=["Element", "File", "HtmlCollection", "HtmlSelectElement"] }
-yew = { git="https://github.com/yewstack/yew.git" }
-yew-agent = { git="https://github.com/yewstack/yew.git" }
-yew-router = { git="https://github.com/yewstack/yew.git", optional=true }
+yew = "0.19"
+yew-agent = "0.1"
+yew-router = { version="0.16", optional=true }
 wasm-bindgen = "0.2"
 serde = "1"
 

--- a/src/columns/mod.rs
+++ b/src/columns/mod.rs
@@ -24,7 +24,7 @@ pub struct ColumnsProps {
 pub fn columns(props: &ColumnsProps) -> Html {
     let class = classes!(
         "columns",
-        props.classes.clone(),
+        &props.classes,
         props.vcentered.then(|| "is-vcentered"),
         props.multiline.then(|| "is-multiline"),
         props.centered.then(|| "is-centered"),
@@ -57,7 +57,7 @@ pub struct ColumnProps {
 #[function_component(Column)]
 pub fn column(props: &ColumnProps) -> Html {
     html! {
-        <div class={classes!("column", props.classes.clone())}>
+        <div class={classes!("column", &props.classes)}>
             {props.children.clone()}
         </div>
     }

--- a/src/columns/mod.rs
+++ b/src/columns/mod.rs
@@ -1,5 +1,4 @@
 use yew::prelude::*;
-use yewtil::NeqAssign;
 
 #[derive(Clone, Debug, Properties, PartialEq)]
 pub struct ColumnsProps {
@@ -21,43 +20,19 @@ pub struct ColumnsProps {
 /// The container for a set of responsive columns.
 ///
 /// [https://bulma.io/documentation/columns/](https://bulma.io/documentation/columns/)
-pub struct Columns {
-    props: ColumnsProps,
-}
-
-impl Component for Columns {
-    type Message = ();
-    type Properties = ColumnsProps;
-
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
-    }
-
-    fn update(&mut self, _: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props.neq_assign(props)
-    }
-
-    fn view(&self) -> Html {
-        let mut classes = Classes::from("columns");
-        classes.push(&self.props.classes);
-        if self.props.vcentered {
-            classes.push("is-vcentered");
-        }
-        if self.props.multiline {
-            classes.push("is-multiline");
-        }
-        if self.props.centered {
-            classes.push("is-centered");
-        }
-        html! {
-            <div class=classes>
-                {self.props.children.clone()}
-            </div>
-        }
+#[function_component(Columns)]
+pub fn columns(props: &ColumnsProps) -> Html {
+    let class = classes!(
+        "columns",
+        props.classes.clone(),
+        props.vcentered.then(|| "is-vcentered"),
+        props.multiline.then(|| "is-multiline"),
+        props.centered.then(|| "is-centered"),
+    );
+    html! {
+        <div {class}>
+            {props.children.clone()}
+        </div>
     }
 }
 
@@ -79,33 +54,11 @@ pub struct ColumnProps {
 /// This component has a very large number of valid class combinations which users may want.
 /// Modelling all of these is particularly for this component, so for now you are encouraged to
 /// add classes to this Component manually via the `classes` prop.
-pub struct Column {
-    props: ColumnProps,
-}
-
-impl Component for Column {
-    type Message = ();
-    type Properties = ColumnProps;
-
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
-    }
-
-    fn update(&mut self, _: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props.neq_assign(props)
-    }
-
-    fn view(&self) -> Html {
-        let mut classes = Classes::from("column");
-        classes.push(&self.props.classes);
-        html! {
-            <div class=classes>
-                {self.props.children.clone()}
-            </div>
-        }
+#[function_component(Column)]
+pub fn column(props: &ColumnProps) -> Html {
+    html! {
+        <div class={classes!("column", props.classes.clone())}>
+            {props.children.clone()}
+        </div>
     }
 }

--- a/src/columns/mod.rs
+++ b/src/columns/mod.rs
@@ -5,7 +5,7 @@ pub struct ColumnsProps {
     #[prop_or_default]
     pub children: Children,
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
     /// Align child columns vertically.
     #[prop_or_default]
     pub vcentered: bool,
@@ -24,7 +24,7 @@ pub struct ColumnsProps {
 pub fn columns(props: &ColumnsProps) -> Html {
     let class = classes!(
         "columns",
-        &props.classes,
+        props.classes.clone(),
         props.vcentered.then_some("is-vcentered"),
         props.multiline.then_some("is-multiline"),
         props.centered.then_some("is-centered"),
@@ -44,7 +44,7 @@ pub struct ColumnProps {
     #[prop_or_default]
     pub children: Children,
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
 }
 
 /// A flexbox-based responsive column.
@@ -57,7 +57,7 @@ pub struct ColumnProps {
 #[function_component(Column)]
 pub fn column(props: &ColumnProps) -> Html {
     html! {
-        <div class={classes!("column", &props.classes)}>
+        <div class={classes!("column", props.classes.clone())}>
             {props.children.clone()}
         </div>
     }

--- a/src/columns/mod.rs
+++ b/src/columns/mod.rs
@@ -25,9 +25,9 @@ pub fn columns(props: &ColumnsProps) -> Html {
     let class = classes!(
         "columns",
         &props.classes,
-        props.vcentered.then(|| "is-vcentered"),
-        props.multiline.then(|| "is-multiline"),
-        props.centered.then(|| "is-centered"),
+        props.vcentered.then_some("is-vcentered"),
+        props.multiline.then_some("is-multiline"),
+        props.centered.then_some("is-centered"),
     );
     html! {
         <div {class}>

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,6 +1,6 @@
 use derive_more::Display;
 use std::borrow::Cow;
-use yew::html::IntoOptPropValue;
+use yew::html::IntoPropValue;
 
 /// Common alignment classes.
 #[derive(Clone, Debug, Display, PartialEq)]
@@ -28,8 +28,8 @@ pub enum Size {
     Large,
 }
 
-impl IntoOptPropValue<Cow<'static, str>> for Size {
-    fn into_opt_prop_value(self) -> Option<Cow<'static, str>> {
-        Some(Cow::from(self.to_string()))
+impl IntoPropValue<Cow<'static, str>> for Size {
+    fn into_prop_value(self) -> Cow<'static, str> {
+        Cow::from(self.to_string())
     }
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use yew::html::IntoPropValue;
 
 /// Common alignment classes.
-#[derive(Clone, Debug, Display, PartialEq)]
+#[derive(Clone, Debug, Display, PartialEq, Eq)]
 #[display(fmt = "is-{}")]
 pub enum Alignment {
     #[display(fmt = "left")]
@@ -15,7 +15,7 @@ pub enum Alignment {
 }
 
 /// Common size classes.
-#[derive(Clone, Debug, Display, PartialEq)]
+#[derive(Clone, Debug, Display, PartialEq, Eq)]
 #[display(fmt = "is-{}")]
 pub enum Size {
     #[display(fmt = "small")]

--- a/src/components/breadcrumb.rs
+++ b/src/components/breadcrumb.rs
@@ -1,6 +1,5 @@
 use derive_more::Display;
 use yew::prelude::*;
-use yewtil::NeqAssign;
 
 use crate::Alignment;
 
@@ -25,45 +24,21 @@ pub struct BreadcrumbProps {
 /// A simple breadcrumb component to improve your navigation experience.
 ///
 /// [https://bulma.io/documentation/components/breadcrumb/](https://bulma.io/documentation/components/breadcrumb/)
-pub struct Breadcrumb {
-    props: BreadcrumbProps,
-}
-
-impl Component for Breadcrumb {
-    type Message = ();
-    type Properties = BreadcrumbProps;
-
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
-    }
-
-    fn update(&mut self, _: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props.neq_assign(props)
-    }
-
-    fn view(&self) -> Html {
-        let mut classes = Classes::from("breadcrumb");
-        classes.push(&self.props.classes);
-        if let Some(size) = &self.props.size {
-            classes.push(&size.to_string());
-        }
-        if let Some(alignment) = &self.props.alignment {
-            classes.push(&alignment.to_string());
-        }
-        if let Some(separator) = &self.props.separator {
-            classes.push(&separator.to_string());
-        }
-        html! {
-            <nav class=classes aria-label="breadcrumbs">
-                <ul>
-                    {self.props.children.clone()}
-                </ul>
-            </nav>
-        }
+#[function_component(Breadcrumb)]
+pub fn breadcrumb(props: &BreadcrumbProps) -> Html {
+    let class = classes!(
+        "breadcrumb",
+        props.classes.clone(),
+        props.size.as_ref().map(|size| size.to_string()),
+        props.alignment.as_ref().map(|alignment| alignment.to_string()),
+        props.separator.as_ref().map(|separator| separator.to_string()),
+    );
+    html! {
+        <nav {class} aria-label="breadcrumbs">
+            <ul>
+                {props.children.clone()}
+            </ul>
+        </nav>
     }
 }
 

--- a/src/components/breadcrumb.rs
+++ b/src/components/breadcrumb.rs
@@ -28,7 +28,7 @@ pub struct BreadcrumbProps {
 pub fn breadcrumb(props: &BreadcrumbProps) -> Html {
     let class = classes!(
         "breadcrumb",
-        props.classes.clone(),
+        &props.classes,
         props.size.as_ref().map(|size| size.to_string()),
         props.alignment.as_ref().map(|alignment| alignment.to_string()),
         props.separator.as_ref().map(|separator| separator.to_string()),

--- a/src/components/breadcrumb.rs
+++ b/src/components/breadcrumb.rs
@@ -9,7 +9,7 @@ pub struct BreadcrumbProps {
     #[prop_or_default]
     pub children: Children,
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
     /// The size of this component.
     #[prop_or_default]
     pub size: Option<BreadcrumbSize>,
@@ -28,7 +28,7 @@ pub struct BreadcrumbProps {
 pub fn breadcrumb(props: &BreadcrumbProps) -> Html {
     let class = classes!(
         "breadcrumb",
-        &props.classes,
+        props.classes.clone(),
         props.size.as_ref().map(|size| size.to_string()),
         props.alignment.as_ref().map(|alignment| alignment.to_string()),
         props.separator.as_ref().map(|separator| separator.to_string()),

--- a/src/components/breadcrumb.rs
+++ b/src/components/breadcrumb.rs
@@ -45,7 +45,7 @@ pub fn breadcrumb(props: &BreadcrumbProps) -> Html {
 /// The 3 sizes available for a breadcrumb.
 ///
 /// https://bulma.io/documentation/components/breadcrumb/#sizes
-#[derive(Clone, Debug, Display, PartialEq)]
+#[derive(Clone, Debug, Display, PartialEq, Eq)]
 #[display(fmt = "are-{}")]
 pub enum BreadcrumbSize {
     #[display(fmt = "small")]
@@ -59,7 +59,7 @@ pub enum BreadcrumbSize {
 /// The 4 additional separators for a breadcrump.
 ///
 /// https://bulma.io/documentation/components/breadcrumb/#alternative-separators
-#[derive(Clone, Debug, Display, PartialEq)]
+#[derive(Clone, Debug, Display, PartialEq, Eq)]
 #[display(fmt = "has-{}-separator")]
 pub enum BreadcrumbSeparator {
     #[display(fmt = "arrow")]

--- a/src/components/card.rs
+++ b/src/components/card.rs
@@ -1,5 +1,4 @@
 use yew::prelude::*;
-use yewtil::NeqAssign;
 
 #[derive(Clone, Debug, Properties, PartialEq)]
 pub struct CardProps {
@@ -12,34 +11,12 @@ pub struct CardProps {
 /// An all-around flexible and composable component; this is the card container.
 ///
 /// [https://bulma.io/documentation/components/card/](https://bulma.io/documentation/components/card/)
-pub struct Card {
-    props: CardProps,
-}
-
-impl Component for Card {
-    type Message = ();
-    type Properties = CardProps;
-
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
-    }
-
-    fn update(&mut self, _: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props.neq_assign(props)
-    }
-
-    fn view(&self) -> Html {
-        let mut classes = Classes::from("card");
-        classes.push(&self.props.classes);
-        html! {
-            <div class=classes>
-                {self.props.children.clone()}
-            </div>
-        }
+#[function_component(Card)]
+pub fn card(props: &CardProps) -> Html {
+    html! {
+        <div class={classes!("card", props.classes.clone())}>
+            {props.children.clone()}
+        </div>
     }
 }
 
@@ -57,34 +34,12 @@ pub struct CardHeaderProps {
 /// A container for card header content; rendered as a horizontal bar with a shadow.
 ///
 /// [https://bulma.io/documentation/components/card/](https://bulma.io/documentation/components/card/)
-pub struct CardHeader {
-    props: CardHeaderProps,
-}
-
-impl Component for CardHeader {
-    type Message = ();
-    type Properties = CardHeaderProps;
-
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
-    }
-
-    fn update(&mut self, _: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props.neq_assign(props)
-    }
-
-    fn view(&self) -> Html {
-        let mut classes = Classes::from("card-header");
-        classes.push(&self.props.classes);
-        html! {
-            <header class=classes>
-                {self.props.children.clone()}
-            </header>
-        }
+#[function_component(CardHeader)]
+pub fn card_header(props: &CardHeaderProps) -> Html {
+    html! {
+        <header class={classes!("card-header", props.classes.clone())}>
+            {props.children.clone()}
+        </header>
     }
 }
 
@@ -102,34 +57,12 @@ pub struct CardImageProps {
 /// A fullwidth container for a responsive image.
 ///
 /// [https://bulma.io/documentation/components/card/](https://bulma.io/documentation/components/card/)
-pub struct CardImage {
-    props: CardImageProps,
-}
-
-impl Component for CardImage {
-    type Message = ();
-    type Properties = CardImageProps;
-
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
-    }
-
-    fn update(&mut self, _: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props.neq_assign(props)
-    }
-
-    fn view(&self) -> Html {
-        let mut classes = Classes::from("card-image");
-        classes.push(&self.props.classes);
-        html! {
-            <div class=classes>
-                {self.props.children.clone()}
-            </div>
-        }
+#[function_component(CardImage)]
+pub fn card_image(props: &CardImageProps) -> Html {
+    html! {
+        <div class={classes!("card-image", props.classes.clone())}>
+            {props.children.clone()}
+        </div>
     }
 }
 
@@ -147,34 +80,12 @@ pub struct CardContentProps {
 /// A container for any other content as the body of the card.
 ///
 /// [https://bulma.io/documentation/components/card/](https://bulma.io/documentation/components/card/)
-pub struct CardContent {
-    props: CardContentProps,
-}
-
-impl Component for CardContent {
-    type Message = ();
-    type Properties = CardContentProps;
-
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
-    }
-
-    fn update(&mut self, _: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props.neq_assign(props)
-    }
-
-    fn view(&self) -> Html {
-        let mut classes = Classes::from("card-content");
-        classes.push(&self.props.classes);
-        html! {
-            <div class=classes>
-                {self.props.children.clone()}
-            </div>
-        }
+#[function_component(CardContent)]
+pub fn card_content(props: &CardContentProps) -> Html {
+    html! {
+        <div class={classes!("card-content", props.classes.clone())}>
+            {props.children.clone()}
+        </div>
     }
 }
 
@@ -192,33 +103,11 @@ pub struct CardFooterProps {
 /// A container for card footer content; rendered as a horizontal list of controls.
 ///
 /// [https://bulma.io/documentation/components/card/](https://bulma.io/documentation/components/card/)
-pub struct CardFooter {
-    props: CardFooterProps,
-}
-
-impl Component for CardFooter {
-    type Message = ();
-    type Properties = CardFooterProps;
-
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
-    }
-
-    fn update(&mut self, _: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props.neq_assign(props)
-    }
-
-    fn view(&self) -> Html {
-        let mut classes = Classes::from("card-footer");
-        classes.push(&self.props.classes);
-        html! {
-            <footer class=classes>
-                {self.props.children.clone()}
-            </footer>
-        }
+#[function_component(CardFooter)]
+pub fn card_footer(props: &CardFooterProps) -> Html {
+    html! {
+        <footer class={classes!("card-footer", props.classes.clone())}>
+            {props.children.clone()}
+        </footer>
     }
 }

--- a/src/components/card.rs
+++ b/src/components/card.rs
@@ -14,7 +14,7 @@ pub struct CardProps {
 #[function_component(Card)]
 pub fn card(props: &CardProps) -> Html {
     html! {
-        <div class={classes!("card", props.classes.clone())}>
+        <div class={classes!("card", &props.classes)}>
             {props.children.clone()}
         </div>
     }
@@ -37,7 +37,7 @@ pub struct CardHeaderProps {
 #[function_component(CardHeader)]
 pub fn card_header(props: &CardHeaderProps) -> Html {
     html! {
-        <header class={classes!("card-header", props.classes.clone())}>
+        <header class={classes!("card-header", &props.classes)}>
             {props.children.clone()}
         </header>
     }
@@ -60,7 +60,7 @@ pub struct CardImageProps {
 #[function_component(CardImage)]
 pub fn card_image(props: &CardImageProps) -> Html {
     html! {
-        <div class={classes!("card-image", props.classes.clone())}>
+        <div class={classes!("card-image", &props.classes)}>
             {props.children.clone()}
         </div>
     }
@@ -83,7 +83,7 @@ pub struct CardContentProps {
 #[function_component(CardContent)]
 pub fn card_content(props: &CardContentProps) -> Html {
     html! {
-        <div class={classes!("card-content", props.classes.clone())}>
+        <div class={classes!("card-content", &props.classes)}>
             {props.children.clone()}
         </div>
     }
@@ -106,7 +106,7 @@ pub struct CardFooterProps {
 #[function_component(CardFooter)]
 pub fn card_footer(props: &CardFooterProps) -> Html {
     html! {
-        <footer class={classes!("card-footer", props.classes.clone())}>
+        <footer class={classes!("card-footer", &props.classes)}>
             {props.children.clone()}
         </footer>
     }

--- a/src/components/card.rs
+++ b/src/components/card.rs
@@ -5,7 +5,7 @@ pub struct CardProps {
     #[prop_or_default]
     pub children: Children,
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
 }
 
 /// An all-around flexible and composable component; this is the card container.
@@ -14,7 +14,7 @@ pub struct CardProps {
 #[function_component(Card)]
 pub fn card(props: &CardProps) -> Html {
     html! {
-        <div class={classes!("card", &props.classes)}>
+        <div class={classes!("card", props.classes.clone())}>
             {props.children.clone()}
         </div>
     }
@@ -28,7 +28,7 @@ pub struct CardHeaderProps {
     #[prop_or_default]
     pub children: Children,
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
 }
 
 /// A container for card header content; rendered as a horizontal bar with a shadow.
@@ -37,7 +37,7 @@ pub struct CardHeaderProps {
 #[function_component(CardHeader)]
 pub fn card_header(props: &CardHeaderProps) -> Html {
     html! {
-        <header class={classes!("card-header", &props.classes)}>
+        <header class={classes!("card-header", props.classes.clone())}>
             {props.children.clone()}
         </header>
     }
@@ -51,7 +51,7 @@ pub struct CardImageProps {
     #[prop_or_default]
     pub children: Children,
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
 }
 
 /// A fullwidth container for a responsive image.
@@ -60,7 +60,7 @@ pub struct CardImageProps {
 #[function_component(CardImage)]
 pub fn card_image(props: &CardImageProps) -> Html {
     html! {
-        <div class={classes!("card-image", &props.classes)}>
+        <div class={classes!("card-image", props.classes.clone())}>
             {props.children.clone()}
         </div>
     }
@@ -74,7 +74,7 @@ pub struct CardContentProps {
     #[prop_or_default]
     pub children: Children,
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
 }
 
 /// A container for any other content as the body of the card.
@@ -83,7 +83,7 @@ pub struct CardContentProps {
 #[function_component(CardContent)]
 pub fn card_content(props: &CardContentProps) -> Html {
     html! {
-        <div class={classes!("card-content", &props.classes)}>
+        <div class={classes!("card-content", props.classes.clone())}>
             {props.children.clone()}
         </div>
     }
@@ -97,7 +97,7 @@ pub struct CardFooterProps {
     #[prop_or_default]
     pub children: Children,
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
 }
 
 /// A container for card footer content; rendered as a horizontal list of controls.
@@ -106,7 +106,7 @@ pub struct CardFooterProps {
 #[function_component(CardFooter)]
 pub fn card_footer(props: &CardFooterProps) -> Html {
     html! {
-        <footer class={classes!("card-footer", &props.classes)}>
+        <footer class={classes!("card-footer", props.classes.clone())}>
             {props.children.clone()}
         </footer>
     }

--- a/src/components/dropdown.rs
+++ b/src/components/dropdown.rs
@@ -1,5 +1,4 @@
 use yew::prelude::*;
-use yewtil::NeqAssign;
 
 use crate::elements::button::Button;
 
@@ -33,8 +32,6 @@ pub enum DropdownMsg {
 ///
 /// [https://bulma.io/documentation/components/dropdown/](https://bulma.io/documentation/components/dropdown/)
 pub struct Dropdown {
-    link: ComponentLink<Self>,
-    props: DropdownProps,
     is_menu_active: bool,
 }
 
@@ -42,12 +39,12 @@ impl Component for Dropdown {
     type Message = DropdownMsg;
     type Properties = DropdownProps;
 
-    fn create(props: Self::Properties, link: ComponentLink<Self>) -> Self {
-        Self { link, props, is_menu_active: false }
+    fn create(_ctx: &Context<Self>) -> Self {
+        Self { is_menu_active: false }
     }
 
-    fn update(&mut self, msg: Self::Message) -> ShouldRender {
-        if self.props.hoverable {
+    fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> bool {
+        if ctx.props().hoverable {
             return false;
         }
         match msg {
@@ -57,36 +54,32 @@ impl Component for Dropdown {
         true
     }
 
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props.neq_assign(props)
-    }
-
-    fn view(&self) -> Html {
-        let mut classes = Classes::from("dropdown");
-        classes.push(&self.props.classes);
-        let opencb = if self.props.hoverable {
-            classes.push("is-hoverable");
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let mut class = Classes::from("dropdown");
+        class.push(&ctx.props().classes);
+        let opencb = if ctx.props().hoverable {
+            class.push("is-hoverable");
             Callback::noop()
         } else {
-            self.link.callback(|_| DropdownMsg::Open)
+            ctx.link().callback(|_| DropdownMsg::Open)
         };
         let overlay = if self.is_menu_active {
-            classes.push("is-active");
-            html! {<div onclick=self.link.callback(|_| DropdownMsg::Close) style="z-index:10;background-color:rgba(0,0,0,0);position:fixed;top:0;bottom:0;left:0;right:0;"></div>}
+            class.push("is-active");
+            html! {<div onclick={ctx.link().callback(|_| DropdownMsg::Close)} style="z-index:10;background-color:rgba(0,0,0,0);position:fixed;top:0;bottom:0;left:0;right:0;"></div>}
         } else {
             html! {}
         };
         html! {
-            <div class=classes>
+            <div {class}>
                 {overlay}
                 <div class="dropdown-trigger">
-                    <Button classes=self.props.button_classes.clone() onclick=opencb>
-                        {self.props.button_html.clone()}
+                    <Button classes={ctx.props().button_classes.clone()} onclick={opencb}>
+                        {ctx.props().button_html.clone()}
                     </Button>
                 </div>
                 <div class="dropdown-menu" role="menu">
                     <div class="dropdown-content">
-                        {self.props.children.clone()}
+                        {ctx.props().children.clone()}
                     </div>
                 </div>
             </div>

--- a/src/components/dropdown.rs
+++ b/src/components/dropdown.rs
@@ -10,13 +10,13 @@ pub struct DropdownProps {
     #[prop_or_default]
     pub children: Children,
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
     /// Make this dropdown triggerable based on hover.
     #[prop_or_default]
     pub hoverable: bool,
     /// Any additional classes to use for the trigger button.
     #[prop_or_default]
-    pub button_classes: Option<Classes>,
+    pub button_classes: Classes,
     /// The content of the trigger button.
     #[prop_or_default]
     pub button_html: Html,
@@ -56,7 +56,7 @@ impl Component for Dropdown {
 
     fn view(&self, ctx: &Context<Self>) -> Html {
         let mut class = Classes::from("dropdown");
-        class.push(&ctx.props().classes);
+        class.push(ctx.props().classes.clone());
         let opencb = if ctx.props().hoverable {
             class.push("is-hoverable");
             Callback::noop()

--- a/src/components/menu.rs
+++ b/src/components/menu.rs
@@ -1,5 +1,4 @@
 use yew::prelude::*;
-use yewtil::NeqAssign;
 
 #[derive(Clone, Debug, Properties, PartialEq)]
 pub struct MenuProps {
@@ -12,34 +11,12 @@ pub struct MenuProps {
 /// A simple menu, for any type of vertical navigation.
 ///
 /// [https://bulma.io/documentation/components/menu/](https://bulma.io/documentation/components/menu/)
-pub struct Menu {
-    props: MenuProps,
-}
-
-impl Component for Menu {
-    type Message = ();
-    type Properties = MenuProps;
-
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
-    }
-
-    fn update(&mut self, _: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props.neq_assign(props)
-    }
-
-    fn view(&self) -> Html {
-        let mut classes = Classes::from("menu");
-        classes.push(&self.props.classes);
-        html! {
-            <aside class=classes>
-                {self.props.children.clone()}
-            </aside>
-        }
+#[function_component(Menu)]
+pub fn menu(props: &MenuProps) -> Html {
+    html! {
+        <aside class={classes!("menu", props.classes.clone())}>
+            {props.children.clone()}
+        </aside>
     }
 }
 
@@ -58,34 +35,12 @@ pub struct MenuListProps {
 /// A container for menu list `li` elements.
 ///
 /// [https://bulma.io/documentation/components/menu/](https://bulma.io/documentation/components/menu/)
-pub struct MenuList {
-    props: MenuListProps,
-}
-
-impl Component for MenuList {
-    type Message = ();
-    type Properties = MenuListProps;
-
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
-    }
-
-    fn update(&mut self, _: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props.neq_assign(props)
-    }
-
-    fn view(&self) -> Html {
-        let mut classes = Classes::from("menu-list");
-        classes.push(&self.props.classes);
-        html! {
-            <ul class=classes>
-                {self.props.children.clone()}
-            </ul>
-        }
+#[function_component(MenuList)]
+pub fn menu_list(props: &MenuListProps) -> Html {
+    html! {
+        <ul class={classes!("menu-list", props.classes.clone())}>
+            {props.children.clone()}
+        </ul>
     }
 }
 
@@ -104,33 +59,11 @@ pub struct MenuLabelProps {
 /// A label for a section of the menu.
 ///
 /// [https://bulma.io/documentation/components/menu/](https://bulma.io/documentation/components/menu/)
-pub struct MenuLabel {
-    props: MenuLabelProps,
-}
-
-impl Component for MenuLabel {
-    type Message = ();
-    type Properties = MenuLabelProps;
-
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
-    }
-
-    fn update(&mut self, _: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props.neq_assign(props)
-    }
-
-    fn view(&self) -> Html {
-        let mut classes = Classes::from("menu-label");
-        classes.push(&self.props.classes);
-        html! {
-            <p class=classes>
-                {self.props.text.clone()}
-            </p>
-        }
+#[function_component(MenuLabel)]
+pub fn menu_label(props: &MenuLabelProps) -> Html {
+    html! {
+        <p class={classes!("menu-label", props.classes.clone())}>
+            {props.text.clone()}
+        </p>
     }
 }

--- a/src/components/menu.rs
+++ b/src/components/menu.rs
@@ -14,7 +14,7 @@ pub struct MenuProps {
 #[function_component(Menu)]
 pub fn menu(props: &MenuProps) -> Html {
     html! {
-        <aside class={classes!("menu", props.classes.clone())}>
+        <aside class={classes!("menu", &props.classes)}>
             {props.children.clone()}
         </aside>
     }
@@ -38,7 +38,7 @@ pub struct MenuListProps {
 #[function_component(MenuList)]
 pub fn menu_list(props: &MenuListProps) -> Html {
     html! {
-        <ul class={classes!("menu-list", props.classes.clone())}>
+        <ul class={classes!("menu-list", &props.classes)}>
             {props.children.clone()}
         </ul>
     }
@@ -62,7 +62,7 @@ pub struct MenuLabelProps {
 #[function_component(MenuLabel)]
 pub fn menu_label(props: &MenuLabelProps) -> Html {
     html! {
-        <p class={classes!("menu-label", props.classes.clone())}>
+        <p class={classes!("menu-label", &props.classes)}>
             {props.text.clone()}
         </p>
     }

--- a/src/components/menu.rs
+++ b/src/components/menu.rs
@@ -5,7 +5,7 @@ pub struct MenuProps {
     #[prop_or_default]
     pub children: Children,
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
 }
 
 /// A simple menu, for any type of vertical navigation.
@@ -14,7 +14,7 @@ pub struct MenuProps {
 #[function_component(Menu)]
 pub fn menu(props: &MenuProps) -> Html {
     html! {
-        <aside class={classes!("menu", &props.classes)}>
+        <aside class={classes!("menu", props.classes.clone())}>
             {props.children.clone()}
         </aside>
     }
@@ -29,7 +29,7 @@ pub struct MenuListProps {
     #[prop_or_default]
     pub children: Children,
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
 }
 
 /// A container for menu list `li` elements.
@@ -38,7 +38,7 @@ pub struct MenuListProps {
 #[function_component(MenuList)]
 pub fn menu_list(props: &MenuListProps) -> Html {
     html! {
-        <ul class={classes!("menu-list", &props.classes)}>
+        <ul class={classes!("menu-list", props.classes.clone())}>
             {props.children.clone()}
         </ul>
     }
@@ -50,7 +50,7 @@ pub fn menu_list(props: &MenuListProps) -> Html {
 #[derive(Clone, Debug, Properties, PartialEq)]
 pub struct MenuLabelProps {
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
     /// The text of the label.
     #[prop_or_default]
     pub text: String,
@@ -62,7 +62,7 @@ pub struct MenuLabelProps {
 #[function_component(MenuLabel)]
 pub fn menu_label(props: &MenuLabelProps) -> Html {
     html! {
-        <p class={classes!("menu-label", &props.classes)}>
+        <p class={classes!("menu-label", props.classes.clone())}>
             {props.text.clone()}
         </p>
     }

--- a/src/components/message.rs
+++ b/src/components/message.rs
@@ -14,7 +14,7 @@ pub struct MessageProps {
 #[function_component(Message)]
 pub fn message(props: &MessageProps) -> Html {
     html! {
-        <article class={classes!("message", props.classes.clone())}>
+        <article class={classes!("message", &props.classes)}>
             {props.children.clone()}
         </article>
     }
@@ -37,7 +37,7 @@ pub struct MessageHeaderProps {
 #[function_component(MessageHeader)]
 pub fn message_header(props: &MessageHeaderProps) -> Html {
     html! {
-        <div class={classes!("message-header", props.classes.clone())}>
+        <div class={classes!("message-header", &props.classes)}>
             {props.children.clone()}
         </div>
     }
@@ -60,7 +60,7 @@ pub struct MessageBodyProps {
 #[function_component(MessageBody)]
 pub fn message_body(props: &MessageBodyProps) -> Html {
     html! {
-        <div class={classes!("message-body", props.classes.clone())}>
+        <div class={classes!("message-body", &props.classes)}>
             {props.children.clone()}
         </div>
     }

--- a/src/components/message.rs
+++ b/src/components/message.rs
@@ -1,5 +1,4 @@
 use yew::prelude::*;
-use yewtil::NeqAssign;
 
 #[derive(Clone, Debug, Properties, PartialEq)]
 pub struct MessageProps {
@@ -12,34 +11,12 @@ pub struct MessageProps {
 /// Colored message blocks, to emphasize part of your page.
 ///
 /// [https://bulma.io/documentation/components/message/](https://bulma.io/documentation/components/message/)
-pub struct Message {
-    props: MessageProps,
-}
-
-impl Component for Message {
-    type Message = ();
-    type Properties = MessageProps;
-
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
-    }
-
-    fn update(&mut self, _: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props.neq_assign(props)
-    }
-
-    fn view(&self) -> Html {
-        let mut classes = Classes::from("message");
-        classes.push(&self.props.classes);
-        html! {
-            <article class=classes>
-                {self.props.children.clone()}
-            </article>
-        }
+#[function_component(Message)]
+pub fn message(props: &MessageProps) -> Html {
+    html! {
+        <article class={classes!("message", props.classes.clone())}>
+            {props.children.clone()}
+        </article>
     }
 }
 
@@ -57,34 +34,12 @@ pub struct MessageHeaderProps {
 /// An optional message header that can hold a title and a delete element.
 ///
 /// [https://bulma.io/documentation/components/message/](https://bulma.io/documentation/components/message/)
-pub struct MessageHeader {
-    props: MessageHeaderProps,
-}
-
-impl Component for MessageHeader {
-    type Message = ();
-    type Properties = MessageHeaderProps;
-
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
-    }
-
-    fn update(&mut self, _: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props.neq_assign(props)
-    }
-
-    fn view(&self) -> Html {
-        let mut classes = Classes::from("message-header");
-        classes.push(&self.props.classes);
-        html! {
-            <div class=classes>
-                {self.props.children.clone()}
-            </div>
-        }
+#[function_component(MessageHeader)]
+pub fn message_header(props: &MessageHeaderProps) -> Html {
+    html! {
+        <div class={classes!("message-header", props.classes.clone())}>
+            {props.children.clone()}
+        </div>
     }
 }
 
@@ -102,33 +57,11 @@ pub struct MessageBodyProps {
 /// A container for the body of a message.
 ///
 /// [https://bulma.io/documentation/components/message/](https://bulma.io/documentation/components/message/)
-pub struct MessageBody {
-    props: MessageBodyProps,
-}
-
-impl Component for MessageBody {
-    type Message = ();
-    type Properties = MessageBodyProps;
-
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
-    }
-
-    fn update(&mut self, _: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props.neq_assign(props)
-    }
-
-    fn view(&self) -> Html {
-        let mut classes = Classes::from("message-body");
-        classes.push(&self.props.classes);
-        html! {
-            <div class=classes>
-                {self.props.children.clone()}
-            </div>
-        }
+#[function_component(MessageBody)]
+pub fn message_body(props: &MessageBodyProps) -> Html {
+    html! {
+        <div class={classes!("message-body", props.classes.clone())}>
+            {props.children.clone()}
+        </div>
     }
 }

--- a/src/components/message.rs
+++ b/src/components/message.rs
@@ -5,7 +5,7 @@ pub struct MessageProps {
     #[prop_or_default]
     pub children: Children,
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
 }
 
 /// Colored message blocks, to emphasize part of your page.
@@ -14,7 +14,7 @@ pub struct MessageProps {
 #[function_component(Message)]
 pub fn message(props: &MessageProps) -> Html {
     html! {
-        <article class={classes!("message", &props.classes)}>
+        <article class={classes!("message", props.classes.clone())}>
             {props.children.clone()}
         </article>
     }
@@ -28,7 +28,7 @@ pub struct MessageHeaderProps {
     #[prop_or_default]
     pub children: Children,
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
 }
 
 /// An optional message header that can hold a title and a delete element.
@@ -37,7 +37,7 @@ pub struct MessageHeaderProps {
 #[function_component(MessageHeader)]
 pub fn message_header(props: &MessageHeaderProps) -> Html {
     html! {
-        <div class={classes!("message-header", &props.classes)}>
+        <div class={classes!("message-header", props.classes.clone())}>
             {props.children.clone()}
         </div>
     }
@@ -51,7 +51,7 @@ pub struct MessageBodyProps {
     #[prop_or_default]
     pub children: Children,
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
 }
 
 /// A container for the body of a message.
@@ -60,7 +60,7 @@ pub struct MessageBodyProps {
 #[function_component(MessageBody)]
 pub fn message_body(props: &MessageBodyProps) -> Html {
     html! {
-        <div class={classes!("message-body", &props.classes)}>
+        <div class={classes!("message-body", props.classes.clone())}>
             {props.children.clone()}
         </div>
     }

--- a/src/components/modal.rs
+++ b/src/components/modal.rs
@@ -1,8 +1,7 @@
 use std::collections::HashSet;
 
 use yew::prelude::*;
-use yew::worker::*;
-use yewtil::NeqAssign;
+use yew_agent::{Agent, AgentLink, Bridge, Bridged, HandlerId};
 
 /// Modal actions.
 pub enum ModalMsg {
@@ -32,8 +31,6 @@ pub struct ModalProps {
 /// See the docs on the `ModalCloser` agent to be able to close your modal instance from anywhere
 /// in your app for maximum flexibility.
 pub struct Modal {
-    props: ModalProps,
-    link: ComponentLink<Self>,
     #[allow(dead_code)]
     subscription: Box<dyn Bridge<ModalCloser>>,
     is_active: bool,
@@ -43,13 +40,13 @@ impl Component for Modal {
     type Message = ModalMsg;
     type Properties = ModalProps;
 
-    fn create(props: Self::Properties, link: ComponentLink<Self>) -> Self {
-        let callback = link.callback(ModalMsg::CloseFromAgent);
+    fn create(ctx: &Context<Self>) -> Self {
+        let callback = ctx.link().callback(ModalMsg::CloseFromAgent);
         let subscription = ModalCloser::bridge(callback);
-        Self { props, link, subscription, is_active: false }
+        Self { subscription, is_active: false }
     }
 
-    fn update(&mut self, msg: Self::Message) -> ShouldRender {
+    fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> bool {
         match msg {
             ModalMsg::Close => {
                 self.is_active = false;
@@ -58,7 +55,7 @@ impl Component for Modal {
                 self.is_active = true;
             }
             ModalMsg::CloseFromAgent(id) => {
-                if id.0 == self.props.id {
+                if id.0 == ctx.props().id {
                     self.is_active = false;
                 } else {
                 }
@@ -67,30 +64,26 @@ impl Component for Modal {
         true
     }
 
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props.neq_assign(props)
-    }
-
-    fn view(&self) -> Html {
-        let mut classes = Classes::from("modal");
-        classes.push(&self.props.classes);
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let mut class = Classes::from("modal");
+        class.push(&ctx.props().classes);
         let (opencb, closecb) = if self.is_active {
-            classes.push("is-active");
-            (Callback::noop(), self.link.callback(|_| ModalMsg::Close))
+            class.push("is-active");
+            (Callback::noop(), ctx.link().callback(|_| ModalMsg::Close))
         } else {
-            (self.link.callback(|_| ModalMsg::Open), Callback::noop())
+            (ctx.link().callback(|_| ModalMsg::Open), Callback::noop())
         };
         html! {
             <>
-            <div onclick=opencb>
-                {self.props.trigger.clone()}
+            <div onclick={opencb}>
+                {ctx.props().trigger.clone()}
             </div>
-            <div id=self.props.id.clone() class=classes>
-                <div class="modal-background" onclick=closecb.clone()></div>
+            <div id={ctx.props().id.clone()} {class}>
+                <div class="modal-background" onclick={closecb.clone()}></div>
                 <div class="modal-content">
-                    {self.props.children.clone()}
+                    {ctx.props().children.clone()}
                 </div>
-                <button class="modal-close is-large" aria-label="close" onclick=closecb></button>
+                <button class="modal-close is-large" aria-label="close" onclick={closecb}></button>
             </div>
             </>
         }
@@ -127,8 +120,6 @@ pub struct ModalCardProps {
 /// See the docs on the `ModalCloser` agent to be able to close your modal instance from anywhere
 /// in your app for maximum flexibility.
 pub struct ModalCard {
-    props: ModalCardProps,
-    link: ComponentLink<Self>,
     #[allow(dead_code)]
     subscription: Box<dyn Bridge<ModalCloser>>,
     is_active: bool,
@@ -138,13 +129,13 @@ impl Component for ModalCard {
     type Message = ModalMsg;
     type Properties = ModalCardProps;
 
-    fn create(props: Self::Properties, link: ComponentLink<Self>) -> Self {
-        let callback = link.callback(ModalMsg::CloseFromAgent);
+    fn create(ctx: &Context<Self>) -> Self {
+        let callback = ctx.link().callback(ModalMsg::CloseFromAgent);
         let subscription = ModalCloser::bridge(callback);
-        Self { props, link, subscription, is_active: false }
+        Self { subscription, is_active: false }
     }
 
-    fn update(&mut self, msg: Self::Message) -> ShouldRender {
+    fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> bool {
         match msg {
             ModalMsg::Close => {
                 self.is_active = false;
@@ -153,7 +144,7 @@ impl Component for ModalCard {
                 self.is_active = true;
             }
             ModalMsg::CloseFromAgent(id) => {
-                if id.0 == self.props.id {
+                if id.0 == ctx.props().id {
                     self.is_active = false;
                 } else {
                 }
@@ -162,39 +153,35 @@ impl Component for ModalCard {
         true
     }
 
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props.neq_assign(props)
-    }
-
-    fn view(&self) -> Html {
-        let mut classes = Classes::from("modal");
-        classes.push(&self.props.classes);
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let mut class = Classes::from("modal");
+        class.push(&ctx.props().classes);
         let (opencb, closecb) = if self.is_active {
-            classes.push("is-active");
-            (Callback::noop(), self.link.callback(|_| ModalMsg::Close))
+            class.push("is-active");
+            (Callback::noop(), ctx.link().callback(|_| ModalMsg::Close))
         } else {
-            (self.link.callback(|_| ModalMsg::Open), Callback::noop())
+            (ctx.link().callback(|_| ModalMsg::Open), Callback::noop())
         };
         html! {
             <>
-            <div onclick=opencb>
-                {self.props.trigger.clone()}
+            <div onclick={opencb}>
+                {ctx.props().trigger.clone()}
             </div>
-            <div id=self.props.id.clone() class=classes>
-                <div class="modal-background" onclick=closecb.clone()></div>
+            <div id={ctx.props().id.clone()} {class}>
+                <div class="modal-background" onclick={closecb.clone()}></div>
                 <div class="modal-card">
                     <header class="modal-card-head">
-                        <p class="modal-card-title">{self.props.title.clone()}</p>
-                        <button class="delete" aria-label="close" onclick=closecb.clone()></button>
+                        <p class="modal-card-title">{ctx.props().title.clone()}</p>
+                        <button class="delete" aria-label="close" onclick={closecb.clone()}></button>
                     </header>
                     <section class="modal-card-body">
-                        {self.props.body.clone()}
+                        {ctx.props().body.clone()}
                     </section>
                     <footer class="modal-card-foot">
-                        {self.props.footer.clone()}
+                        {ctx.props().footer.clone()}
                     </footer>
                 </div>
-                <button class="modal-close is-large" aria-label="close" onclick=closecb.clone()></button>
+                <button class="modal-close is-large" aria-label="close" onclick={closecb}></button>
             </div>
             </>
         }
@@ -257,7 +244,7 @@ pub struct ModalCloser {
 }
 
 impl Agent for ModalCloser {
-    type Reach = Context<Self>;
+    type Reach = yew_agent::Context<Self>;
     type Message = ();
     type Input = ModalCloseMsg; // The agent receives requests to close modals by ID.
     type Output = ModalCloseMsg; // The agent forwards the input to all registered modals.

--- a/src/components/modal.rs
+++ b/src/components/modal.rs
@@ -21,7 +21,7 @@ pub struct ModalProps {
     #[prop_or_default]
     pub trigger: Html,
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
 }
 
 /// A classic modal overlay, in which you can include any content you want.
@@ -66,7 +66,7 @@ impl Component for Modal {
 
     fn view(&self, ctx: &Context<Self>) -> Html {
         let mut class = Classes::from("modal");
-        class.push(&ctx.props().classes);
+        class.push(ctx.props().classes.clone());
         let (opencb, closecb) = if self.is_active {
             class.push("is-active");
             (Callback::noop(), ctx.link().callback(|_| ModalMsg::Close))
@@ -110,7 +110,7 @@ pub struct ModalCardProps {
     #[prop_or_default]
     pub trigger: Html,
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
 }
 
 /// A classic modal with a header, body, and footer section.
@@ -155,7 +155,7 @@ impl Component for ModalCard {
 
     fn view(&self, ctx: &Context<Self>) -> Html {
         let mut class = Classes::from("modal");
-        class.push(&ctx.props().classes);
+        class.push(ctx.props().classes.clone());
         let (opencb, closecb) = if self.is_active {
             class.push("is-active");
             (Callback::noop(), ctx.link().callback(|_| ModalMsg::Close))

--- a/src/components/navbar.rs
+++ b/src/components/navbar.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::redundant_closure_call)]
-
 use derive_more::Display;
 use yew::prelude::*;
 

--- a/src/components/navbar.rs
+++ b/src/components/navbar.rs
@@ -218,7 +218,7 @@ pub struct NavbarItemProps {
 pub fn navbar_item(props: &NavbarItemProps) -> Html {
     let class = classes!(
         "navbar-item",
-        props.classes.clone(),
+        &props.classes,
         props.has_dropdown.then(|| "has-dropdown"),
         props.expanded.then(|| "is-expanded"),
         props.tab.then(|| "is-tab"),
@@ -261,7 +261,7 @@ pub struct NavbarDividerProps {
 /// [https://bulma.io/documentation/components/navbar/#dropdown-menu](https://bulma.io/documentation/components/navbar/#dropdown-menu)
 #[function_component(NavbarDivider)]
 pub fn navbar_divider(props: &NavbarDividerProps) -> Html {
-    html! { <hr class={classes!("navbar-divider", props.classes.clone())} /> }
+    html! { <hr class={classes!("navbar-divider", &props.classes)} /> }
 }
 
 //////////////////////////////////////////////////////////////////////////////

--- a/src/components/navbar.rs
+++ b/src/components/navbar.rs
@@ -2,7 +2,6 @@
 
 use derive_more::Display;
 use yew::prelude::*;
-use yewtil::NeqAssign;
 
 use crate::components::dropdown::DropdownMsg;
 
@@ -58,8 +57,6 @@ pub struct NavbarProps {
 ///
 /// [https://bulma.io/documentation/components/navbar/](https://bulma.io/documentation/components/navbar/)
 pub struct Navbar {
-    props: NavbarProps,
-    link: ComponentLink<Self>,
     is_menu_open: bool,
 }
 
@@ -67,11 +64,11 @@ impl Component for Navbar {
     type Message = NavbarMsg;
     type Properties = NavbarProps;
 
-    fn create(props: Self::Properties, link: ComponentLink<Self>) -> Self {
-        Self { props, link, is_menu_open: false }
+    fn create(_ctx: &Context<Self>) -> Self {
+        Self { is_menu_open: false }
     }
 
-    fn update(&mut self, msg: Self::Message) -> ShouldRender {
+    fn update(&mut self, _ctx: &Context<Self>, msg: Self::Message) -> bool {
         match msg {
             NavbarMsg::ToggleMenu => {
                 self.is_menu_open = !self.is_menu_open;
@@ -80,34 +77,30 @@ impl Component for Navbar {
         true
     }
 
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props.neq_assign(props)
-    }
-
-    fn view(&self) -> Html {
+    fn view(&self, ctx: &Context<Self>) -> Html {
         // navbar classes
-        let mut classes = Classes::from("navbar");
-        classes.push(&self.props.classes);
-        if let Some(fixed) = &self.props.fixed {
-            classes.push(&fixed.to_string());
+        let mut class = Classes::from("navbar");
+        class.push(&ctx.props().classes);
+        if let Some(fixed) = &ctx.props().fixed {
+            class.push(&fixed.to_string());
         }
 
         // navbar-menu classes
         let mut navclasses = Classes::from("navbar-menu");
         let mut burgerclasses = Classes::from("navbar-burger");
-        burgerclasses.push(&self.props.navburger_classes);
+        burgerclasses.push(&ctx.props().navburger_classes);
         if self.is_menu_open {
             navclasses.push("is-active");
             burgerclasses.push("is-active");
         }
-        let togglecb = self.link.callback(|_| NavbarMsg::ToggleMenu);
-        let navbrand = if let Some(navbrand) = &self.props.navbrand {
+        let togglecb = ctx.link().callback(|_| NavbarMsg::ToggleMenu);
+        let navbrand = if let Some(navbrand) = &ctx.props().navbrand {
             html! {
                 <div class="navbar-brand">
                     {navbrand.clone()}
-                    {if self.props.navburger {
+                    {if ctx.props().navburger {
                         html! {
-                            <a class=burgerclasses onclick=togglecb
+                            <a class={burgerclasses} onclick={togglecb}
                                 role="button" aria-label="menu"
                                 aria-expanded={if self.is_menu_open { "true" } else { "false" }}
                             >
@@ -124,12 +117,12 @@ impl Component for Navbar {
         } else {
             html! {}
         };
-        let navstart = if let Some(navstart) = &self.props.navstart {
+        let navstart = if let Some(navstart) = &ctx.props().navstart {
             html! {<div class="navbar-start">{navstart.clone()}</div>}
         } else {
             html! {}
         };
-        let navend = if let Some(navend) = &self.props.navend {
+        let navend = if let Some(navend) = &ctx.props().navend {
             html! {<div class="navbar-end">{navend.clone()}</div>}
         } else {
             html! {}
@@ -137,22 +130,22 @@ impl Component for Navbar {
         let contents = html! {
             <>
             {navbrand}
-            <div class=navclasses>
+            <div class={navclasses}>
                 {navstart}
                 {navend}
             </div>
             </>
         };
 
-        if self.props.padded {
+        if ctx.props().padded {
             html! {
-                <nav class=classes role="navigation" aria-label="main navigation">
+                <nav {class} role="navigation" aria-label="main navigation">
                     <div class="container">{contents}</div>
                 </nav>
             }
         } else {
             html! {
-                <nav class=classes role="navigation" aria-label="main navigation">{contents}</nav>
+                <nav {class} role="navigation" aria-label="main navigation">{contents}</nav>
             }
         }
     }
@@ -223,61 +216,34 @@ pub struct NavbarItemProps {
 /// A single element of the navbar.
 ///
 /// [https://bulma.io/documentation/components/navbar/](https://bulma.io/documentation/components/navbar/)
-pub struct NavbarItem {
-    props: NavbarItemProps,
-}
-
-impl Component for NavbarItem {
-    type Message = ();
-    type Properties = NavbarItemProps;
-
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
-    }
-
-    fn update(&mut self, _: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props.neq_assign(props)
-    }
-
-    fn view(&self) -> Html {
-        // navbar classes
-        let mut classes = Classes::from("navbar-item");
-        classes.push(&self.props.classes);
-        if self.props.has_dropdown {
-            classes.push("has-dropdown");
-        }
-        if self.props.expanded {
-            classes.push("is-expanded");
-        }
-        if self.props.tab {
-            classes.push("is-tab");
-        }
-        if self.props.active {
-            classes.push("is-active");
-        }
-        match self.props.tag {
-            NavbarItemTag::A => {
-                html! {
-                    <a
-                        class=classes
-                        href=self.props.href.clone().unwrap_or_default()
-                        rel=self.props.rel.clone().unwrap_or_default()
-                        target=self.props.target.clone().unwrap_or_default()
-                    >
-                        {self.props.children.clone()}
-                    </a>
-                }
+#[function_component(NavbarItem)]
+pub fn navbar_item(props: &NavbarItemProps) -> Html {
+    let class = classes!(
+        "navbar-item",
+        props.classes.clone(),
+        props.has_dropdown.then(|| "has-dropdown"),
+        props.expanded.then(|| "is-expanded"),
+        props.tab.then(|| "is-tab"),
+        props.active.then(|| "is-active"),
+    );
+    match props.tag {
+        NavbarItemTag::A => {
+            html! {
+                <a
+                    {class}
+                    href={props.href.clone().unwrap_or_default()}
+                    rel={props.rel.clone().unwrap_or_default()}
+                    target={props.target.clone().unwrap_or_default()}
+                >
+                    {props.children.clone()}
+                </a>
             }
-            NavbarItemTag::Div => {
-                html! {
-                    <div class=classes>
-                        {self.props.children.clone()}
-                    </div>
-                }
+        }
+        NavbarItemTag::Div => {
+            html! {
+                <div {class}>
+                    {props.children.clone()}
+                </div>
             }
         }
     }
@@ -295,33 +261,9 @@ pub struct NavbarDividerProps {
 /// An element to display a horizontal rule in a navbar-dropdown.
 ///
 /// [https://bulma.io/documentation/components/navbar/#dropdown-menu](https://bulma.io/documentation/components/navbar/#dropdown-menu)
-pub struct NavbarDivider {
-    props: NavbarDividerProps,
-}
-
-impl Component for NavbarDivider {
-    type Message = ();
-    type Properties = NavbarDividerProps;
-
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
-    }
-
-    fn update(&mut self, _: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props.neq_assign(props)
-    }
-
-    fn view(&self) -> Html {
-        let mut classes = Classes::from("navbar-divider");
-        classes.push(&self.props.classes);
-        html! {
-            <hr class=classes/>
-        }
-    }
+#[function_component(NavbarDivider)]
+pub fn navbar_divider(props: &NavbarDividerProps) -> Html {
+    html! { <hr class={classes!("navbar-divider", props.classes.clone())} /> }
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -360,8 +302,6 @@ pub struct NavbarDropdownProps {
 ///
 /// [https://bulma.io/documentation/components/navbar/#dropdown-menu](https://bulma.io/documentation/components/navbar/#dropdown-menu)
 pub struct NavbarDropdown {
-    props: NavbarDropdownProps,
-    link: ComponentLink<Self>,
     is_menu_active: bool,
 }
 
@@ -369,12 +309,12 @@ impl Component for NavbarDropdown {
     type Message = DropdownMsg;
     type Properties = NavbarDropdownProps;
 
-    fn create(props: Self::Properties, link: ComponentLink<Self>) -> Self {
-        Self { props, link, is_menu_active: false }
+    fn create(_ctx: &Context<Self>) -> Self {
+        Self { is_menu_active: false }
     }
 
-    fn update(&mut self, msg: Self::Message) -> ShouldRender {
-        if self.props.hoverable {
+    fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> bool {
+        if ctx.props().hoverable {
             return false;
         }
         match msg {
@@ -384,51 +324,47 @@ impl Component for NavbarDropdown {
         true
     }
 
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props.neq_assign(props)
-    }
-
-    fn view(&self) -> Html {
+    fn view(&self, ctx: &Context<Self>) -> Html {
         // navbar-item classes
-        let mut classes = Classes::from("navbar-item has-dropdown");
-        classes.push(&self.props.classes);
-        if self.props.dropup {
-            classes.push("has-dropdown-up");
+        let mut class = Classes::from("navbar-item has-dropdown");
+        class.push(&ctx.props().classes);
+        if ctx.props().dropup {
+            class.push("has-dropdown-up");
         }
 
         // navbar-dropdown classes
         let mut dropclasses = Classes::from("navbar-dropdown");
-        if self.props.right {
+        if ctx.props().right {
             dropclasses.push("is-right");
         }
-        if self.props.boxed {
+        if ctx.props().boxed {
             dropclasses.push("is-boxed");
         }
 
         // navbar-link classes
         let mut linkclasses = Classes::from("navbar-link");
-        if self.props.arrowless {
+        if ctx.props().arrowless {
             linkclasses.push("is-arrowless");
         }
 
-        let opencb = if self.props.hoverable {
-            classes.push("is-hoverable");
+        let opencb = if ctx.props().hoverable {
+            class.push("is-hoverable");
             Callback::noop()
         } else {
-            self.link.callback(|_| DropdownMsg::Open)
+            ctx.link().callback(|_| DropdownMsg::Open)
         };
         let overlay = if self.is_menu_active {
-            classes.push("is-active");
-            html! {<div onclick=self.link.callback(|_| DropdownMsg::Close) style="z-index:10;background-color:rgba(0,0,0,0);position:fixed;top:0;bottom:0;left:0;right:0;"></div>}
+            class.push("is-active");
+            html! {<div onclick={ctx.link().callback(|_| DropdownMsg::Close)} style="z-index:10;background-color:rgba(0,0,0,0);position:fixed;top:0;bottom:0;left:0;right:0;"></div>}
         } else {
             html! {}
         };
         html! {
-            <div class=classes>
+            <div {class}>
                 {overlay}
-                <a class=linkclasses onclick=opencb>{self.props.navlink.clone()}</a>
-                <div class=dropclasses>
-                    {self.props.children.clone()}
+                <a class={linkclasses} onclick={opencb}>{ctx.props().navlink.clone()}</a>
+                <div class={dropclasses}>
+                    {ctx.props().children.clone()}
                 </div>
             </div>
         }

--- a/src/components/navbar.rs
+++ b/src/components/navbar.rs
@@ -155,7 +155,7 @@ impl Component for Navbar {
 ///
 /// NOTE WELL: in order to work properly, the root `html` or `body` element must be configured with
 /// the corresponding `has-navbar-fixed-top` or `has-navbar-fixed-bottom` class.
-#[derive(Clone, Debug, Display, PartialEq)]
+#[derive(Clone, Debug, Display, PartialEq, Eq)]
 #[display(fmt = "is-{}")]
 pub enum NavbarFixed {
     #[display(fmt = "fixed-top")]
@@ -170,7 +170,7 @@ pub enum NavbarFixed {
 /// The two HTML tags allowed for a navbar-item.
 ///
 /// [https://bulma.io/documentation/components/navbar/#navbar-item](https://bulma.io/documentation/components/navbar/#navbar-item)
-#[derive(Clone, Debug, Display, PartialEq)]
+#[derive(Clone, Debug, Display, PartialEq, Eq)]
 pub enum NavbarItemTag {
     #[display(fmt = "a")]
     A,
@@ -219,10 +219,10 @@ pub fn navbar_item(props: &NavbarItemProps) -> Html {
     let class = classes!(
         "navbar-item",
         &props.classes,
-        props.has_dropdown.then(|| "has-dropdown"),
-        props.expanded.then(|| "is-expanded"),
-        props.tab.then(|| "is-tab"),
-        props.active.then(|| "is-active"),
+        props.has_dropdown.then_some("has-dropdown"),
+        props.expanded.then_some("is-expanded"),
+        props.tab.then_some("is-tab"),
+        props.active.then_some("is-active"),
     );
     match props.tag {
         NavbarItemTag::A => {

--- a/src/components/navbar.rs
+++ b/src/components/navbar.rs
@@ -13,7 +13,7 @@ pub struct NavbarProps {
     #[prop_or_default]
     pub children: Children,
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
     /// Make the navbar fixed to the top or bottom of the UI.
     #[prop_or_default]
     pub fixed: Option<NavbarFixed>,
@@ -48,7 +48,7 @@ pub struct NavbarProps {
     pub navburger: bool,
     /// Extra classes for the navbar burger.
     #[prop_or_default]
-    pub navburger_classes: Option<Classes>,
+    pub navburger_classes: Classes,
 }
 
 /// A responsive horizontal navbar that can support images, links, buttons, and dropdowns.
@@ -78,7 +78,7 @@ impl Component for Navbar {
     fn view(&self, ctx: &Context<Self>) -> Html {
         // navbar classes
         let mut class = Classes::from("navbar");
-        class.push(&ctx.props().classes);
+        class.push(ctx.props().classes.clone());
         if let Some(fixed) = &ctx.props().fixed {
             class.push(&fixed.to_string());
         }
@@ -86,7 +86,7 @@ impl Component for Navbar {
         // navbar-menu classes
         let mut navclasses = Classes::from("navbar-menu");
         let mut burgerclasses = Classes::from("navbar-burger");
-        burgerclasses.push(&ctx.props().navburger_classes);
+        burgerclasses.push(ctx.props().navburger_classes.clone());
         if self.is_menu_open {
             navclasses.push("is-active");
             burgerclasses.push("is-active");
@@ -183,7 +183,7 @@ pub struct NavbarItemProps {
     #[prop_or_default]
     pub children: Children,
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
     /// The HTML tag to use for this component.
     #[prop_or_else(|| NavbarItemTag::Div)]
     pub tag: NavbarItemTag,
@@ -218,7 +218,7 @@ pub struct NavbarItemProps {
 pub fn navbar_item(props: &NavbarItemProps) -> Html {
     let class = classes!(
         "navbar-item",
-        &props.classes,
+        props.classes.clone(),
         props.has_dropdown.then_some("has-dropdown"),
         props.expanded.then_some("is-expanded"),
         props.tab.then_some("is-tab"),
@@ -253,7 +253,7 @@ pub fn navbar_item(props: &NavbarItemProps) -> Html {
 #[derive(Clone, Debug, Properties, PartialEq)]
 pub struct NavbarDividerProps {
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
 }
 
 /// An element to display a horizontal rule in a navbar-dropdown.
@@ -261,7 +261,7 @@ pub struct NavbarDividerProps {
 /// [https://bulma.io/documentation/components/navbar/#dropdown-menu](https://bulma.io/documentation/components/navbar/#dropdown-menu)
 #[function_component(NavbarDivider)]
 pub fn navbar_divider(props: &NavbarDividerProps) -> Html {
-    html! { <hr class={classes!("navbar-divider", &props.classes)} /> }
+    html! { <hr class={classes!("navbar-divider", props.classes.clone())} /> }
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -273,7 +273,7 @@ pub struct NavbarDropdownProps {
     #[prop_or_default]
     pub children: Children,
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
     /// The contents of the navbar-link used for triggering the dropdown menu.
     pub navlink: Html,
     /// Make this dropdown triggerable based on hover.
@@ -325,7 +325,7 @@ impl Component for NavbarDropdown {
     fn view(&self, ctx: &Context<Self>) -> Html {
         // navbar-item classes
         let mut class = Classes::from("navbar-item has-dropdown");
-        class.push(&ctx.props().classes);
+        class.push(ctx.props().classes.clone());
         if ctx.props().dropup {
             class.push("has-dropdown-up");
         }

--- a/src/components/pagination.rs
+++ b/src/components/pagination.rs
@@ -34,7 +34,7 @@ pub struct PaginationProps {
 pub fn pagination(props: &PaginationProps) -> Html {
     let class = classes!(
         "pagination",
-        props.classes.clone(),
+        &props.classes,
         props.size.as_ref().map(|size| size.to_string()),
         props.alignment.as_ref().map(|alignment| alignment.to_string()),
         props.rounded.then(|| "is-rounded"),

--- a/src/components/pagination.rs
+++ b/src/components/pagination.rs
@@ -142,7 +142,6 @@ mod router {
             }
         }
 
-        #[allow(deprecated)]
         fn view(&self, ctx: &Context<Self>) -> Html {
             html! {
                 <Link<R, Q>

--- a/src/components/pagination.rs
+++ b/src/components/pagination.rs
@@ -62,7 +62,7 @@ pub struct PaginationItemProps {
     #[prop_or_default]
     pub label: String,
     /// The click handler for this component.
-    #[prop_or_else(Callback::noop)]
+    #[prop_or_default]
     pub onclick: Callback<MouseEvent>,
 }
 

--- a/src/components/pagination.rs
+++ b/src/components/pagination.rs
@@ -10,7 +10,7 @@ pub struct PaginationProps {
     #[prop_or_default]
     pub children: Children,
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
     /// The size of this component.
     #[prop_or_default]
     pub size: Option<Size>,
@@ -34,7 +34,7 @@ pub struct PaginationProps {
 pub fn pagination(props: &PaginationProps) -> Html {
     let class = classes!(
         "pagination",
-        &props.classes,
+        props.classes.clone(),
         props.size.as_ref().map(|size| size.to_string()),
         props.alignment.as_ref().map(|alignment| alignment.to_string()),
         props.rounded.then_some("is-rounded"),

--- a/src/components/pagination.rs
+++ b/src/components/pagination.rs
@@ -37,7 +37,7 @@ pub fn pagination(props: &PaginationProps) -> Html {
         &props.classes,
         props.size.as_ref().map(|size| size.to_string()),
         props.alignment.as_ref().map(|alignment| alignment.to_string()),
-        props.rounded.then(|| "is-rounded"),
+        props.rounded.then_some("is-rounded"),
     );
     html! {
         <nav {class} role="navigation" aria-label="pagination">
@@ -79,7 +79,7 @@ pub fn pagination_item(props: &PaginationItemProps) -> Html {
 }
 
 /// A pagination item type.
-#[derive(Clone, Debug, Display, PartialEq)]
+#[derive(Clone, Debug, Display, PartialEq, Eq)]
 #[display(fmt = "pagination-{}")]
 pub enum PaginationItemType {
     /// A pagination link for a specific page number.

--- a/src/components/panel.rs
+++ b/src/components/panel.rs
@@ -2,7 +2,6 @@
 
 use yew::events::MouseEvent;
 use yew::prelude::*;
-use yewtil::NeqAssign;
 
 #[derive(Clone, Debug, Properties, PartialEq)]
 pub struct PanelProps {
@@ -18,35 +17,14 @@ pub struct PanelProps {
 /// A composable panel, for compact controls.
 ///
 /// [https://bulma.io/documentation/components/panel/](https://bulma.io/documentation/components/panel/)
-pub struct Panel {
-    props: PanelProps,
-}
-
-impl Component for Panel {
-    type Message = ();
-    type Properties = PanelProps;
-
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
-    }
-
-    fn update(&mut self, _: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props.neq_assign(props)
-    }
-
-    fn view(&self) -> Html {
-        let mut classes = Classes::from("panel");
-        classes.push(&self.props.classes);
-        html! {
-            <nav class=classes>
-                <p class="panel-heading">{self.props.heading.clone()}</p>
-                {self.props.children.clone()}
-            </nav>
-        }
+#[function_component(Panel)]
+pub fn panel(props: &PanelProps) -> Html {
+    let class = classes!("panel", props.classes.clone());
+    html! {
+        <nav {class}>
+            <p class="panel-heading">{props.heading.clone()}</p>
+            {props.children.clone()}
+        </nav>
     }
 }
 
@@ -62,33 +40,9 @@ pub struct PanelTabsProps {
 /// A container for the navigation tabs of a panel.
 ///
 /// [https://bulma.io/documentation/components/panel/](https://bulma.io/documentation/components/panel/)
-pub struct PanelTabs {
-    props: PanelTabsProps,
-}
-
-impl Component for PanelTabs {
-    type Message = ();
-    type Properties = PanelTabsProps;
-
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
-    }
-
-    fn update(&mut self, _: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props.neq_assign(props)
-    }
-
-    fn view(&self) -> Html {
-        html! {
-            <p class="panel-tabs">
-                {self.props.children.clone()}
-            </p>
-        }
-    }
+#[function_component(PanelTabs)]
+pub fn panel_tabs(props: &PanelTabsProps) -> Html {
+    html! { <p class="panel-tabs">{props.children.clone()}</p> }
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -112,36 +66,12 @@ pub struct PanelBlockProps {
 /// An individual element of the panel.
 ///
 /// [https://bulma.io/documentation/components/panel/](https://bulma.io/documentation/components/panel/)
-pub struct PanelBlock {
-    props: PanelBlockProps,
-}
-
-impl Component for PanelBlock {
-    type Message = ();
-    type Properties = PanelBlockProps;
-
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
-    }
-
-    fn update(&mut self, _: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props.neq_assign(props)
-    }
-
-    fn view(&self) -> Html {
-        let mut classes = Classes::from("panel-block");
-        if self.props.active {
-            classes.push("is-active");
-        }
-        let tag = self.props.tag.clone();
-        html! {
-            <@{tag} class=classes onclick=self.props.onclick.clone()>
-                {self.props.children.clone()}
-            </@>
-        }
+#[function_component(PanelBlock)]
+pub fn panel_block(props: &PanelBlockProps) -> Html {
+    let class = classes!("panel-block", props.active.then(|| "is-active"));
+    html! {
+        <@{props.tag.clone()} {class} onclick={props.onclick.clone()}>
+            {props.children.clone()}
+        </@>
     }
 }

--- a/src/components/panel.rs
+++ b/src/components/panel.rs
@@ -17,7 +17,7 @@ pub struct PanelProps {
 /// [https://bulma.io/documentation/components/panel/](https://bulma.io/documentation/components/panel/)
 #[function_component(Panel)]
 pub fn panel(props: &PanelProps) -> Html {
-    let class = classes!("panel", props.classes.clone());
+    let class = classes!("panel", &props.classes);
     html! {
         <nav {class}>
             <p class="panel-heading">{props.heading.clone()}</p>

--- a/src/components/panel.rs
+++ b/src/components/panel.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::redundant_closure_call)]
-
 use yew::events::MouseEvent;
 use yew::prelude::*;
 

--- a/src/components/panel.rs
+++ b/src/components/panel.rs
@@ -57,7 +57,7 @@ pub struct PanelBlockProps {
     #[prop_or_default]
     pub active: bool,
     /// The click handler for this element.
-    #[prop_or_else(Callback::noop)]
+    #[prop_or_default]
     pub onclick: Callback<MouseEvent>,
 }
 

--- a/src/components/panel.rs
+++ b/src/components/panel.rs
@@ -66,7 +66,7 @@ pub struct PanelBlockProps {
 /// [https://bulma.io/documentation/components/panel/](https://bulma.io/documentation/components/panel/)
 #[function_component(PanelBlock)]
 pub fn panel_block(props: &PanelBlockProps) -> Html {
-    let class = classes!("panel-block", props.active.then(|| "is-active"));
+    let class = classes!("panel-block", props.active.then_some("is-active"));
     html! {
         <@{props.tag.clone()} {class} onclick={props.onclick.clone()}>
             {props.children.clone()}

--- a/src/components/panel.rs
+++ b/src/components/panel.rs
@@ -6,7 +6,7 @@ pub struct PanelProps {
     #[prop_or_default]
     pub children: Children,
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
     /// The HTML content of this panel's heading; it is automatically wrapped in a `p.panel-heading`.
     #[prop_or_default]
     pub heading: Html,
@@ -17,7 +17,7 @@ pub struct PanelProps {
 /// [https://bulma.io/documentation/components/panel/](https://bulma.io/documentation/components/panel/)
 #[function_component(Panel)]
 pub fn panel(props: &PanelProps) -> Html {
-    let class = classes!("panel", &props.classes);
+    let class = classes!("panel", props.classes.clone());
     html! {
         <nav {class}>
             <p class="panel-heading">{props.heading.clone()}</p>

--- a/src/components/tabs.rs
+++ b/src/components/tabs.rs
@@ -1,5 +1,4 @@
 use yew::prelude::*;
-use yewtil::NeqAssign;
 
 use crate::{Alignment, Size};
 
@@ -35,53 +34,23 @@ pub struct TabsProps {
 ///
 /// For integration with Yew Router, it is recommended that the `RouterButton` or `RouterAnchor`
 /// components be used as the individual tab elements for this component.
-pub struct Tabs {
-    props: TabsProps,
-}
-
-impl Component for Tabs {
-    type Message = ();
-    type Properties = TabsProps;
-
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
-    }
-
-    fn update(&mut self, _: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props.neq_assign(props)
-    }
-
-    fn view(&self) -> Html {
-        let mut classes = Classes::from("tabs");
-        classes.push(&self.props.classes);
-        if let Some(alignment) = &self.props.alignment {
-            classes.push(&alignment.to_string());
-        }
-        if let Some(size) = &self.props.size {
-            classes.push(&size.to_string());
-        }
-        if self.props.boxed {
-            classes.push("is-boxed");
-        }
-        if self.props.toggle {
-            classes.push("is-toggle");
-        }
-        if self.props.rounded {
-            classes.push("is-rounded");
-        }
-        if self.props.fullwidth {
-            classes.push("is-fullwidth");
-        }
-        html! {
-            <div class=classes>
-                <ul>
-                    {self.props.children.clone()}
-                </ul>
-            </div>
-        }
+#[function_component(Tabs)]
+pub fn tabs(props: &TabsProps) -> Html {
+    let class = classes!(
+        "tabs",
+        props.classes.clone(),
+        props.alignment.as_ref().map(ToString::to_string),
+        props.size.as_ref().map(ToString::to_string),
+        props.boxed.then(|| "is-boxed"),
+        props.toggle.then(|| "is-toggle"),
+        props.rounded.then(|| "is-rounded"),
+        props.fullwidth.then(|| "is-fullwidth"),
+    );
+    html! {
+        <div {class}>
+            <ul>
+                {props.children.clone()}
+            </ul>
+        </div>
     }
 }

--- a/src/components/tabs.rs
+++ b/src/components/tabs.rs
@@ -38,7 +38,7 @@ pub struct TabsProps {
 pub fn tabs(props: &TabsProps) -> Html {
     let class = classes!(
         "tabs",
-        props.classes.clone(),
+        &props.classes,
         props.alignment.as_ref().map(ToString::to_string),
         props.size.as_ref().map(ToString::to_string),
         props.boxed.then(|| "is-boxed"),

--- a/src/components/tabs.rs
+++ b/src/components/tabs.rs
@@ -7,7 +7,7 @@ pub struct TabsProps {
     #[prop_or_default]
     pub children: Children,
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
     /// The alignment of this component.
     #[prop_or_default]
     pub alignment: Option<Alignment>,
@@ -38,7 +38,7 @@ pub struct TabsProps {
 pub fn tabs(props: &TabsProps) -> Html {
     let class = classes!(
         "tabs",
-        &props.classes,
+        props.classes.clone(),
         props.alignment.as_ref().map(ToString::to_string),
         props.size.as_ref().map(ToString::to_string),
         props.boxed.then_some("is-boxed"),

--- a/src/components/tabs.rs
+++ b/src/components/tabs.rs
@@ -41,10 +41,10 @@ pub fn tabs(props: &TabsProps) -> Html {
         &props.classes,
         props.alignment.as_ref().map(ToString::to_string),
         props.size.as_ref().map(ToString::to_string),
-        props.boxed.then(|| "is-boxed"),
-        props.toggle.then(|| "is-toggle"),
-        props.rounded.then(|| "is-rounded"),
-        props.fullwidth.then(|| "is-fullwidth"),
+        props.boxed.then_some("is-boxed"),
+        props.toggle.then_some("is-toggle"),
+        props.rounded.then_some("is-rounded"),
+        props.fullwidth.then_some("is-fullwidth"),
     );
     html! {
         <div {class}>

--- a/src/elements/block.rs
+++ b/src/elements/block.rs
@@ -13,7 +13,7 @@ pub struct BlockProps {
 /// [https://bulma.io/documentation/elements/block/](https://bulma.io/documentation/elements/block/)
 #[function_component(Block)]
 pub fn block(props: &BlockProps) -> Html {
-    let class = classes!("block", props.classes.clone());
+    let class = classes!("block", &props.classes);
     html! {
         <div {class}>
             {props.children.clone()}

--- a/src/elements/block.rs
+++ b/src/elements/block.rs
@@ -1,5 +1,4 @@
 use yew::prelude::*;
-use yewtil::NeqAssign;
 
 #[derive(Clone, Debug, Properties, PartialEq)]
 pub struct BlockProps {
@@ -12,33 +11,12 @@ pub struct BlockProps {
 /// Bulma’s most basic spacer block
 ///
 /// [https://bulma.io/documentation/elements/block/](https://bulma.io/documentation/elements/block/)
-pub struct Block {
-    props: BlockProps,
-}
-
-impl Component for Block {
-    type Message = ();
-    type Properties = BlockProps;
-
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
-    }
-
-    fn update(&mut self, _: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props.neq_assign(props)
-    }
-
-    fn view(&self) -> Html {
-        let mut classes = Classes::from("block");
-        classes.push(&self.props.classes);
-        html! {
-            <div class=classes>
-                {self.props.children.clone()}
-            </div>
-        }
+#[function_component(Block)]
+pub fn block(props: &BlockProps) -> Html {
+    let class = classes!("block", props.classes.clone());
+    html! {
+        <div {class}>
+            {props.children.clone()}
+        </div>
     }
 }

--- a/src/elements/block.rs
+++ b/src/elements/block.rs
@@ -5,7 +5,7 @@ pub struct BlockProps {
     #[prop_or_default]
     pub children: Children,
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
 }
 
 /// Bulma’s most basic spacer block
@@ -13,7 +13,7 @@ pub struct BlockProps {
 /// [https://bulma.io/documentation/elements/block/](https://bulma.io/documentation/elements/block/)
 #[function_component(Block)]
 pub fn block(props: &BlockProps) -> Html {
-    let class = classes!("block", &props.classes);
+    let class = classes!("block", props.classes.clone());
     html! {
         <div {class}>
             {props.children.clone()}

--- a/src/elements/box.rs
+++ b/src/elements/box.rs
@@ -1,5 +1,4 @@
 use yew::prelude::*;
-use yewtil::NeqAssign;
 
 #[derive(Clone, Debug, Properties, PartialEq)]
 pub struct BoxProps {
@@ -12,33 +11,12 @@ pub struct BoxProps {
 /// A white box to contain other elements.
 ///
 /// [https://bulma.io/documentation/elements/box/](https://bulma.io/documentation/elements/box/)
-pub struct Box {
-    props: BoxProps,
-}
-
-impl Component for Box {
-    type Message = ();
-    type Properties = BoxProps;
-
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
-    }
-
-    fn update(&mut self, _: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props.neq_assign(props)
-    }
-
-    fn view(&self) -> Html {
-        let mut classes = Classes::from("box");
-        classes.push(&self.props.classes);
-        html! {
-            <div class=classes>
-                {self.props.children.clone()}
-            </div>
-        }
+#[function_component(Box)]
+pub fn r#box(props: &BoxProps) -> Html {
+    let class = classes!("box", props.classes.clone());
+    html! {
+        <div {class}>
+            {props.children.clone()}
+        </div>
     }
 }

--- a/src/elements/box.rs
+++ b/src/elements/box.rs
@@ -13,9 +13,8 @@ pub struct BoxProps {
 /// [https://bulma.io/documentation/elements/box/](https://bulma.io/documentation/elements/box/)
 #[function_component(Box)]
 pub fn r#box(props: &BoxProps) -> Html {
-    let class = classes!("box", props.classes.clone());
     html! {
-        <div {class}>
+        <div class={classes!("box", &props.classes)}>
             {props.children.clone()}
         </div>
     }

--- a/src/elements/box.rs
+++ b/src/elements/box.rs
@@ -5,7 +5,7 @@ pub struct BoxProps {
     #[prop_or_default]
     pub children: Children,
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
 }
 
 /// A white box to contain other elements.
@@ -14,7 +14,7 @@ pub struct BoxProps {
 #[function_component(Box)]
 pub fn r#box(props: &BoxProps) -> Html {
     html! {
-        <div class={classes!("box", &props.classes)}>
+        <div class={classes!("box", props.classes.clone())}>
             {props.children.clone()}
         </div>
     }

--- a/src/elements/button.rs
+++ b/src/elements/button.rs
@@ -18,7 +18,7 @@ pub struct ButtonsProps {
 /// [https://bulma.io/documentation/elements/button/](https://bulma.io/documentation/elements/button/)
 #[function_component(Buttons)]
 pub fn buttons(props: &ButtonsProps) -> Html {
-    let class = classes!("buttons", props.classes.clone(), props.size.as_ref().map(ToString::to_string));
+    let class = classes!("buttons", &props.classes, props.size.as_ref().map(ToString::to_string));
     html! {
         <div {class}>
             {props.children.clone()}
@@ -70,7 +70,7 @@ pub struct ButtonProps {
 pub fn button(props: &ButtonProps) -> Html {
     let class = classes!(
         "button",
-        props.classes.clone(),
+        &props.classes,
         props.loading.then(|| "is-loading"),
         props.r#static.then(|| "is-static")
     );
@@ -227,7 +227,7 @@ pub struct ButtonAnchorProps {
 pub fn button_anchor(props: &ButtonAnchorProps) -> Html {
     let class = classes!(
         "button",
-        props.classes.clone(),
+        &props.classes,
         props.loading.then(|| "is-loading"),
         props.r#static.then(|| "is-static")
     );
@@ -273,7 +273,7 @@ pub struct ButtonInputSubmitProps {
 pub fn button_input_submit(props: &ButtonInputSubmitProps) -> Html {
     let class = classes!(
         "button",
-        props.classes.clone(),
+        &props.classes,
         props.loading.then(|| "is-loading"),
         props.r#static.then(|| "is-static"),
     );
@@ -310,7 +310,7 @@ pub struct ButtonInputResetProps {
 pub fn button_input_reset(props: &ButtonInputResetProps) -> Html {
     let class = classes!(
         "button",
-        props.classes.clone(),
+        &props.classes,
         props.loading.then(|| "is-loading"),
         props.r#static.then(|| "is-static"),
     );

--- a/src/elements/button.rs
+++ b/src/elements/button.rs
@@ -1,7 +1,6 @@
 use derive_more::Display;
 use yew::events::{Event, FocusEvent, MouseEvent};
 use yew::prelude::*;
-use yewtil::NeqAssign;
 
 #[derive(Clone, Debug, Properties, PartialEq)]
 pub struct ButtonsProps {
@@ -17,39 +16,48 @@ pub struct ButtonsProps {
 /// A container for a group of buttons.
 ///
 /// [https://bulma.io/documentation/elements/button/](https://bulma.io/documentation/elements/button/)
-pub struct Buttons {
-    props: ButtonsProps,
-}
-
-impl Component for Buttons {
-    type Message = ();
-    type Properties = ButtonsProps;
-
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
-    }
-
-    fn update(&mut self, _: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props.neq_assign(props)
-    }
-
-    fn view(&self) -> Html {
-        let mut classes = Classes::from("buttons");
-        classes.push(&self.props.classes);
-        if let Some(size) = &self.props.size {
-            classes.push(&size.to_string());
-        }
-        html! {
-            <div class=classes>
-                {self.props.children.clone()}
-            </div>
-        }
+#[function_component(Buttons)]
+pub fn buttons(props: &ButtonsProps) -> Html {
+    let class = classes!("buttons", props.classes.clone(), props.size.as_ref().map(ToString::to_string));
+    html! {
+        <div {class}>
+            {props.children.clone()}
+        </div>
     }
 }
+// pub struct Buttons {
+//     props: ButtonsProps,
+// }
+
+// impl Component for Buttons {
+//     type Message = ();
+//     type Properties = ButtonsProps;
+
+//     fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
+//         Self { props }
+//     }
+
+//     fn update(&mut self, _: Self::Message) -> ShouldRender {
+//         false
+//     }
+
+//     fn change(&mut self, props: Self::Properties) -> ShouldRender {
+//         self.props.neq_assign(props)
+//     }
+
+//     fn view(&self) -> Html {
+//         let mut classes = Classes::from("buttons");
+//         classes.push(&self.props.classes);
+//         if let Some(size) = &self.props.size {
+//             classes.push(&size.to_string());
+//         }
+//         html! {
+//             <div class=classes>
+//                 {self.props.children.clone()}
+//             </div>
+//         }
+//     }
+// }
 
 /// The 3 sizes available for a button group.
 ///
@@ -91,40 +99,18 @@ pub struct ButtonProps {
 /// A button element.
 ///
 /// [https://bulma.io/documentation/elements/button/](https://bulma.io/documentation/elements/button/)
-pub struct Button {
-    props: ButtonProps,
-}
-
-impl Component for Button {
-    type Message = ();
-    type Properties = ButtonProps;
-
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
-    }
-
-    fn update(&mut self, _: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props.neq_assign(props)
-    }
-
-    fn view(&self) -> Html {
-        let mut classes = Classes::from("button");
-        classes.push(&self.props.classes);
-        if self.props.loading {
-            classes.push("is-loading")
-        }
-        if self.props.r#static {
-            classes.push("is-static")
-        }
-        html! {
-            <button class=classes onclick=self.props.onclick.clone() disabled=self.props.disabled>
-                {self.props.children.clone()}
-            </button>
-        }
+#[function_component(Button)]
+pub fn button(props: &ButtonProps) -> Html {
+    let class = classes!(
+        "button",
+        props.classes.clone(),
+        props.loading.then(|| "is-loading"),
+        props.r#static.then(|| "is-static")
+    );
+    html! {
+        <button {class} onclick={props.onclick.clone()} disabled={props.disabled}>
+            {props.children.clone()}
+        </button>
     }
 }
 
@@ -134,13 +120,14 @@ impl Component for Button {
 #[cfg(feature = "router")]
 mod router {
     use super::*;
-    use yew_router::components::{RouterAnchor, RouterButton as RouterBtn};
-    use yew_router::{RouterState, Switch};
+    use serde::Serialize;
+    use yew_router::components::Link;
+    use yew_router::Routable;
 
     #[derive(Clone, Properties, PartialEq)]
-    pub struct ButtonRouterProps<SW: Switch + Clone + PartialEq + 'static> {
+    pub struct ButtonRouterProps<R: Routable + Clone + PartialEq + 'static> {
         /// The Switched item representing the route.
-        pub route: SW,
+        pub route: R,
         /// Html inside the component.
         #[prop_or_default]
         pub children: Children,
@@ -159,84 +146,74 @@ mod router {
     }
 
     /// A Yew Router button element with Bulma styling.
-    pub struct ButtonRouter<SW: Switch + Clone + PartialEq + 'static, STATE: RouterState = ()> {
-        props: ButtonRouterProps<SW>,
-        marker: std::marker::PhantomData<STATE>,
+    pub struct ButtonRouter<R: Routable + Clone + PartialEq + 'static, Q: Clone + PartialEq + Serialize + 'static = ()> {
+        _route: std::marker::PhantomData<R>,
+        _query: std::marker::PhantomData<Q>,
     }
 
-    impl<SW: Switch + Clone + PartialEq + 'static, STATE: RouterState> Component for ButtonRouter<SW, STATE> {
+    impl<R: Routable + Clone + PartialEq + 'static, Q: Clone + PartialEq + Serialize + 'static> Component for ButtonRouter<R, Q> {
         type Message = ();
-        type Properties = ButtonRouterProps<SW>;
+        type Properties = ButtonRouterProps<R>;
 
-        fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-            Self { props, marker: std::marker::PhantomData }
-        }
-
-        fn update(&mut self, _: Self::Message) -> ShouldRender {
-            false
-        }
-
-        fn change(&mut self, props: Self::Properties) -> ShouldRender {
-            self.props.neq_assign(props)
+        fn create(_ctx: &Context<Self>) -> Self {
+            Self {
+                _route: std::marker::PhantomData,
+                _query: std::marker::PhantomData,
+            }
         }
 
         #[allow(deprecated)]
-        fn view(&self) -> Html {
-            let mut classes = Classes::from(&self.props.classes);
+        fn view(&self, ctx: &Context<Self>) -> Html {
+            let mut classes = Classes::from(&ctx.props().classes);
             if !classes.contains("button") {
                 classes.push("button")
             }
-            if self.props.loading {
+            if ctx.props().loading {
                 classes.push("is-loading");
             }
             html! {
-                <RouterBtn<SW, STATE>
-                    route=self.props.route.clone()
-                    disabled=self.props.disabled
-                    classes=classes.to_string()
-                    children=self.props.children.clone()
+                <Link<R, Q>
+                    to={ctx.props().route.clone()}
+                    disabled={ctx.props().disabled}
+                    {classes}
+                    children={ctx.props().children.clone()}
                 />
             }
         }
     }
 
     /// A Yew Router anchor button element with Bulma styling.
-    pub struct ButtonAnchorRouter<SW: Switch + Clone + PartialEq + 'static, STATE: RouterState = ()> {
-        props: ButtonRouterProps<SW>,
-        marker: std::marker::PhantomData<STATE>,
+    pub struct ButtonAnchorRouter<R: Routable + Clone + PartialEq + 'static, Q: Clone + PartialEq + Serialize + 'static = ()> {
+        _route: std::marker::PhantomData<R>,
+        _query: std::marker::PhantomData<Q>,
     }
 
-    impl<SW: Switch + Clone + PartialEq + 'static, STATE: RouterState> Component for ButtonAnchorRouter<SW, STATE> {
+    impl<R: Routable + Clone + PartialEq + 'static, Q: Clone + PartialEq + Serialize + 'static> Component for ButtonAnchorRouter<R, Q> {
         type Message = ();
-        type Properties = ButtonRouterProps<SW>;
+        type Properties = ButtonRouterProps<R>;
 
-        fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-            Self { props, marker: std::marker::PhantomData }
-        }
-
-        fn update(&mut self, _: Self::Message) -> ShouldRender {
-            false
-        }
-
-        fn change(&mut self, props: Self::Properties) -> ShouldRender {
-            self.props.neq_assign(props)
+        fn create(_ctx: &Context<Self>) -> Self {
+            Self {
+                _route: std::marker::PhantomData,
+                _query: std::marker::PhantomData,
+            }
         }
 
         #[allow(deprecated)]
-        fn view(&self) -> Html {
-            let mut classes = Classes::from(&self.props.classes);
+        fn view(&self, ctx: &Context<Self>) -> Html {
+            let mut classes = Classes::from(&ctx.props().classes);
             if !classes.contains("button") {
                 classes.push("button")
             }
-            if self.props.loading {
+            if ctx.props().loading {
                 classes.push("is-loading");
             }
             html! {
-                <RouterAnchor<SW, STATE>
-                    route=self.props.route.clone()
-                    disabled=self.props.disabled
-                    classes=classes.to_string()
-                    children=self.props.children.clone()
+                <Link<R, Q>
+                    to={ctx.props().route.clone()}
+                    disabled={ctx.props().disabled}
+                    {classes}
+                    children={ctx.props().children.clone()}
                 />
             }
         }
@@ -281,47 +258,25 @@ pub struct ButtonAnchorProps {
 /// An anchor element styled as a button.
 ///
 /// [https://bulma.io/documentation/elements/button/](https://bulma.io/documentation/elements/button/)
-pub struct ButtonAnchor {
-    props: ButtonAnchorProps,
-}
-
-impl Component for ButtonAnchor {
-    type Message = ();
-    type Properties = ButtonAnchorProps;
-
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
-    }
-
-    fn update(&mut self, _: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props.neq_assign(props)
-    }
-
-    fn view(&self) -> Html {
-        let mut classes = Classes::from("button");
-        classes.push(&self.props.classes);
-        if self.props.loading {
-            classes.push("is-loading")
-        }
-        if self.props.r#static {
-            classes.push("is-static")
-        }
-        html! {
-            <a
-                class=classes
-                onclick=self.props.onclick.clone()
-                href=self.props.href.clone()
-                rel=self.props.rel.clone().unwrap_or_default()
-                target=self.props.target.clone().unwrap_or_default()
-                disabled=self.props.disabled
-            >
-                {self.props.children.clone()}
-            </a>
-        }
+#[function_component(ButtonAnchor)]
+pub fn button_anchor(props: &ButtonAnchorProps) -> Html {
+    let class = classes!(
+        "button",
+        props.classes.clone(),
+        props.loading.then(|| "is-loading"),
+        props.r#static.then(|| "is-static")
+    );
+    html! {
+        <a
+            {class}
+            onclick={props.onclick.clone()}
+            href={props.href.clone()}
+            rel={props.rel.clone().unwrap_or_default()}
+            target={props.target.clone().unwrap_or_default()}
+            disabled={props.disabled}
+        >
+            {props.children.clone()}
+        </a>
     }
 }
 
@@ -349,38 +304,16 @@ pub struct ButtonInputSubmitProps {
 /// An input element with `type="submit"` styled as a button.
 ///
 /// [https://bulma.io/documentation/elements/button/](https://bulma.io/documentation/elements/button/)
-pub struct ButtonInputSubmit {
-    props: ButtonInputSubmitProps,
-}
-
-impl Component for ButtonInputSubmit {
-    type Message = ();
-    type Properties = ButtonInputSubmitProps;
-
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
-    }
-
-    fn update(&mut self, _: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props.neq_assign(props)
-    }
-
-    fn view(&self) -> Html {
-        let mut classes = Classes::from("button");
-        classes.push(&self.props.classes);
-        if self.props.loading {
-            classes.push("is-loading")
-        }
-        if self.props.r#static {
-            classes.push("is-static")
-        }
-        html! {
-            <input type="submit" class=classes onsubmit=self.props.onsubmit.clone() disabled=self.props.disabled/>
-        }
+#[function_component(ButtonInputSubmit)]
+pub fn button_input_submit(props: &ButtonInputSubmitProps) -> Html {
+    let class = classes!(
+        "button",
+        props.classes.clone(),
+        props.loading.then(|| "is-loading"),
+        props.r#static.then(|| "is-static"),
+    );
+    html! {
+        <input type="submit" {class} onsubmit={props.onsubmit.clone()} disabled={props.disabled} />
     }
 }
 
@@ -408,37 +341,15 @@ pub struct ButtonInputResetProps {
 /// An input element with `type="reset"` styled as a button.
 ///
 /// [https://bulma.io/documentation/elements/button/](https://bulma.io/documentation/elements/button/)
-pub struct ButtonInputReset {
-    props: ButtonInputResetProps,
-}
-
-impl Component for ButtonInputReset {
-    type Message = ();
-    type Properties = ButtonInputResetProps;
-
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
-    }
-
-    fn update(&mut self, _: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props.neq_assign(props)
-    }
-
-    fn view(&self) -> Html {
-        let mut classes = Classes::from("button");
-        classes.push(&self.props.classes);
-        if self.props.loading {
-            classes.push("is-loading")
-        }
-        if self.props.r#static {
-            classes.push("is-static")
-        }
-        html! {
-            <input type="reset" class=classes onreset=self.props.onreset.clone() disabled=self.props.disabled/>
-        }
+#[function_component(ButtonInputReset)]
+pub fn button_input_reset(props: &ButtonInputResetProps) -> Html {
+    let class = classes!(
+        "button",
+        props.classes.clone(),
+        props.loading.then(|| "is-loading"),
+        props.r#static.then(|| "is-static"),
+    );
+    html! {
+        <input type="reset" {class} onreset={props.onreset.clone()} disabled={props.disabled} />
     }
 }

--- a/src/elements/button.rs
+++ b/src/elements/button.rs
@@ -25,39 +25,6 @@ pub fn buttons(props: &ButtonsProps) -> Html {
         </div>
     }
 }
-// pub struct Buttons {
-//     props: ButtonsProps,
-// }
-
-// impl Component for Buttons {
-//     type Message = ();
-//     type Properties = ButtonsProps;
-
-//     fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-//         Self { props }
-//     }
-
-//     fn update(&mut self, _: Self::Message) -> ShouldRender {
-//         false
-//     }
-
-//     fn change(&mut self, props: Self::Properties) -> ShouldRender {
-//         self.props.neq_assign(props)
-//     }
-
-//     fn view(&self) -> Html {
-//         let mut classes = Classes::from("buttons");
-//         classes.push(&self.props.classes);
-//         if let Some(size) = &self.props.size {
-//             classes.push(&size.to_string());
-//         }
-//         html! {
-//             <div class=classes>
-//                 {self.props.children.clone()}
-//             </div>
-//         }
-//     }
-// }
 
 /// The 3 sizes available for a button group.
 ///
@@ -162,7 +129,6 @@ mod router {
             }
         }
 
-        #[allow(deprecated)]
         fn view(&self, ctx: &Context<Self>) -> Html {
             let mut classes = Classes::from(&ctx.props().classes);
             if !classes.contains("button") {
@@ -199,7 +165,6 @@ mod router {
             }
         }
 
-        #[allow(deprecated)]
         fn view(&self, ctx: &Context<Self>) -> Html {
             let mut classes = Classes::from(&ctx.props().classes);
             if !classes.contains("button") {

--- a/src/elements/button.rs
+++ b/src/elements/button.rs
@@ -50,7 +50,7 @@ pub struct ButtonProps {
     #[prop_or_default]
     pub classes: Option<Classes>,
     /// The click handler to use for this component.
-    #[prop_or_else(Callback::noop)]
+    #[prop_or_default]
     pub onclick: Callback<MouseEvent>,
     /// Render a loading spinner within this component.
     #[prop_or_default]
@@ -201,7 +201,7 @@ pub struct ButtonAnchorProps {
     #[prop_or_default]
     pub href: String,
     /// The click handler to use for this component.
-    #[prop_or_else(Callback::noop)]
+    #[prop_or_default]
     pub onclick: Callback<MouseEvent>,
     /// Render a loading spinner within this component.
     #[prop_or_default]
@@ -253,7 +253,7 @@ pub struct ButtonInputSubmitProps {
     #[prop_or_default]
     pub classes: Option<Classes>,
     /// The submit handler to use for this component.
-    #[prop_or_else(Callback::noop)]
+    #[prop_or_default]
     pub onsubmit: Callback<FocusEvent>,
     /// Render a loading spinner within this component.
     #[prop_or_default]
@@ -290,7 +290,7 @@ pub struct ButtonInputResetProps {
     #[prop_or_default]
     pub classes: Option<Classes>,
     /// The reset handler to use for this component.
-    #[prop_or_else(Callback::noop)]
+    #[prop_or_default]
     pub onreset: Callback<Event>,
     /// Render a loading spinner within this component.
     #[prop_or_default]

--- a/src/elements/button.rs
+++ b/src/elements/button.rs
@@ -7,7 +7,7 @@ pub struct ButtonsProps {
     #[prop_or_default]
     pub children: Children,
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
     /// The size for all buttons within this group.
     #[prop_or_default]
     pub size: Option<ButtonGroupSize>,
@@ -18,7 +18,7 @@ pub struct ButtonsProps {
 /// [https://bulma.io/documentation/elements/button/](https://bulma.io/documentation/elements/button/)
 #[function_component(Buttons)]
 pub fn buttons(props: &ButtonsProps) -> Html {
-    let class = classes!("buttons", &props.classes, props.size.as_ref().map(ToString::to_string));
+    let class = classes!("buttons", props.classes.clone(), props.size.as_ref().map(ToString::to_string));
     html! {
         <div {class}>
             {props.children.clone()}
@@ -48,7 +48,7 @@ pub struct ButtonProps {
     #[prop_or_default]
     pub children: Children,
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
     /// The click handler to use for this component.
     #[prop_or_default]
     pub onclick: Callback<MouseEvent>,
@@ -70,7 +70,7 @@ pub struct ButtonProps {
 pub fn button(props: &ButtonProps) -> Html {
     let class = classes!(
         "button",
-        &props.classes,
+        props.classes.clone(),
         props.loading.then_some("is-loading"),
         props.r#static.then_some("is-static")
     );
@@ -100,7 +100,7 @@ mod router {
         pub children: Children,
         /// Classes to be added to component.
         #[prop_or_default]
-        pub classes: Option<Classes>,
+        pub classes: Classes,
         /// Render a loading spinner within this component.
         #[prop_or_default]
         pub loading: bool,
@@ -130,13 +130,8 @@ mod router {
         }
 
         fn view(&self, ctx: &Context<Self>) -> Html {
-            let mut classes = Classes::from(&ctx.props().classes);
-            if !classes.contains("button") {
-                classes.push("button")
-            }
-            if ctx.props().loading {
-                classes.push("is-loading");
-            }
+            let loading = ctx.props().loading.then_some("is-loading");
+            let classes = classes!(ctx.props().classes.clone(), "button", loading);
             html! {
                 <Link<R, Q>
                     to={ctx.props().route.clone()}
@@ -166,13 +161,8 @@ mod router {
         }
 
         fn view(&self, ctx: &Context<Self>) -> Html {
-            let mut classes = Classes::from(&ctx.props().classes);
-            if !classes.contains("button") {
-                classes.push("button")
-            }
-            if ctx.props().loading {
-                classes.push("is-loading");
-            }
+            let loading = ctx.props().loading.then_some("is-loading");
+            let classes = classes!(ctx.props().classes.clone(), "button", loading);
             html! {
                 <Link<R, Q>
                     to={ctx.props().route.clone()}
@@ -196,7 +186,7 @@ pub struct ButtonAnchorProps {
     #[prop_or_default]
     pub children: Children,
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
     /// The `href` attribute value to use for this component.
     #[prop_or_default]
     pub href: String,
@@ -227,7 +217,7 @@ pub struct ButtonAnchorProps {
 pub fn button_anchor(props: &ButtonAnchorProps) -> Html {
     let class = classes!(
         "button",
-        &props.classes,
+        props.classes.clone(),
         props.loading.then_some("is-loading"),
         props.r#static.then_some("is-static")
     );
@@ -251,7 +241,7 @@ pub fn button_anchor(props: &ButtonAnchorProps) -> Html {
 #[derive(Clone, Debug, Properties, PartialEq)]
 pub struct ButtonInputSubmitProps {
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
     /// The submit handler to use for this component.
     #[prop_or_default]
     pub onsubmit: Callback<FocusEvent>,
@@ -273,7 +263,7 @@ pub struct ButtonInputSubmitProps {
 pub fn button_input_submit(props: &ButtonInputSubmitProps) -> Html {
     let class = classes!(
         "button",
-        &props.classes,
+        props.classes.clone(),
         props.loading.then_some("is-loading"),
         props.r#static.then_some("is-static"),
     );
@@ -288,7 +278,7 @@ pub fn button_input_submit(props: &ButtonInputSubmitProps) -> Html {
 #[derive(Clone, Debug, Properties, PartialEq)]
 pub struct ButtonInputResetProps {
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
     /// The reset handler to use for this component.
     #[prop_or_default]
     pub onreset: Callback<Event>,
@@ -310,7 +300,7 @@ pub struct ButtonInputResetProps {
 pub fn button_input_reset(props: &ButtonInputResetProps) -> Html {
     let class = classes!(
         "button",
-        &props.classes,
+        props.classes.clone(),
         props.loading.then_some("is-loading"),
         props.r#static.then_some("is-static"),
     );

--- a/src/elements/button.rs
+++ b/src/elements/button.rs
@@ -29,7 +29,7 @@ pub fn buttons(props: &ButtonsProps) -> Html {
 /// The 3 sizes available for a button group.
 ///
 /// https://bulma.io/documentation/elements/button/#sizes
-#[derive(Clone, Debug, Display, PartialEq)]
+#[derive(Clone, Debug, Display, PartialEq, Eq)]
 #[display(fmt = "are-{}")]
 pub enum ButtonGroupSize {
     #[display(fmt = "small")]
@@ -71,8 +71,8 @@ pub fn button(props: &ButtonProps) -> Html {
     let class = classes!(
         "button",
         &props.classes,
-        props.loading.then(|| "is-loading"),
-        props.r#static.then(|| "is-static")
+        props.loading.then_some("is-loading"),
+        props.r#static.then_some("is-static")
     );
     html! {
         <button {class} onclick={props.onclick.clone()} disabled={props.disabled}>
@@ -228,8 +228,8 @@ pub fn button_anchor(props: &ButtonAnchorProps) -> Html {
     let class = classes!(
         "button",
         &props.classes,
-        props.loading.then(|| "is-loading"),
-        props.r#static.then(|| "is-static")
+        props.loading.then_some("is-loading"),
+        props.r#static.then_some("is-static")
     );
     html! {
         <a
@@ -274,8 +274,8 @@ pub fn button_input_submit(props: &ButtonInputSubmitProps) -> Html {
     let class = classes!(
         "button",
         &props.classes,
-        props.loading.then(|| "is-loading"),
-        props.r#static.then(|| "is-static"),
+        props.loading.then_some("is-loading"),
+        props.r#static.then_some("is-static"),
     );
     html! {
         <input type="submit" {class} onsubmit={props.onsubmit.clone()} disabled={props.disabled} />
@@ -311,8 +311,8 @@ pub fn button_input_reset(props: &ButtonInputResetProps) -> Html {
     let class = classes!(
         "button",
         &props.classes,
-        props.loading.then(|| "is-loading"),
-        props.r#static.then(|| "is-static"),
+        props.loading.then_some("is-loading"),
+        props.r#static.then_some("is-static"),
     );
     html! {
         <input type="reset" {class} onreset={props.onreset.clone()} disabled={props.disabled} />

--- a/src/elements/content.rs
+++ b/src/elements/content.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::redundant_closure_call)]
-
 use yew::prelude::*;
 
 #[derive(Clone, Debug, Properties, PartialEq)]

--- a/src/elements/content.rs
+++ b/src/elements/content.rs
@@ -16,9 +16,8 @@ pub struct ContentProps {
 /// [https://bulma.io/documentation/elements/content/](https://bulma.io/documentation/elements/content/)
 #[function_component(Content)]
 pub fn content(props: &ContentProps) -> Html {
-    let class = classes!("content", props.classes.clone());
     html! {
-        <@{props.tag.clone()} {class}>
+        <@{props.tag.clone()} class={classes!("content", &props.classes)}>
             {props.children.clone()}
         </@>
     }

--- a/src/elements/content.rs
+++ b/src/elements/content.rs
@@ -1,7 +1,6 @@
 #![allow(clippy::redundant_closure_call)]
 
 use yew::prelude::*;
-use yewtil::NeqAssign;
 
 #[derive(Clone, Debug, Properties, PartialEq)]
 pub struct ContentProps {
@@ -17,34 +16,12 @@ pub struct ContentProps {
 /// A single component to wrap WYSIWYG generated content, where only HTML tags are available.
 ///
 /// [https://bulma.io/documentation/elements/content/](https://bulma.io/documentation/elements/content/)
-pub struct Content {
-    props: ContentProps,
-}
-
-impl Component for Content {
-    type Message = ();
-    type Properties = ContentProps;
-
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
-    }
-
-    fn update(&mut self, _: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props.neq_assign(props)
-    }
-
-    fn view(&self) -> Html {
-        let mut classes = Classes::from("content");
-        classes.push(&self.props.classes);
-        let tag = self.props.tag.clone();
-        html! {
-            <@{tag} class=classes>
-                {self.props.children.clone()}
-            </@>
-        }
+#[function_component(Content)]
+pub fn content(props: &ContentProps) -> Html {
+    let class = classes!("content", props.classes.clone());
+    html! {
+        <@{props.tag.clone()} {class}>
+            {props.children.clone()}
+        </@>
     }
 }

--- a/src/elements/content.rs
+++ b/src/elements/content.rs
@@ -5,7 +5,7 @@ pub struct ContentProps {
     #[prop_or_default]
     pub children: Children,
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
     /// The HTML tag to use for this component.
     #[prop_or_else(|| "div".into())]
     pub tag: String,
@@ -17,7 +17,7 @@ pub struct ContentProps {
 #[function_component(Content)]
 pub fn content(props: &ContentProps) -> Html {
     html! {
-        <@{props.tag.clone()} class={classes!("content", &props.classes)}>
+        <@{props.tag.clone()} class={classes!("content", props.classes.clone())}>
             {props.children.clone()}
         </@>
     }

--- a/src/elements/delete.rs
+++ b/src/elements/delete.rs
@@ -19,7 +19,7 @@ pub struct DeleteProps {
 /// [https://bulma.io/documentation/elements/delete/](https://bulma.io/documentation/elements/delete/)
 #[function_component(Delete)]
 pub fn delete(props: &DeleteProps) -> Html {
-    let class = classes!("delete", props.classes.clone());
+    let class = classes!("delete", &props.classes);
     html! {
         <@{props.tag.clone()} {class} onclick={props.onclick.clone()}>
             {props.children.clone()}

--- a/src/elements/delete.rs
+++ b/src/elements/delete.rs
@@ -10,7 +10,7 @@ pub struct DeleteProps {
     #[prop_or_else(|| "button".into())]
     pub tag: String,
     /// The click handler to use for this component.
-    #[prop_or_else(Callback::noop)]
+    #[prop_or_default]
     pub onclick: Callback<MouseEvent>,
 }
 

--- a/src/elements/delete.rs
+++ b/src/elements/delete.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::redundant_closure_call)]
-use yew::events::MouseEvent;
 use yew::prelude::*;
 
 #[derive(Clone, Debug, Properties, PartialEq)]

--- a/src/elements/delete.rs
+++ b/src/elements/delete.rs
@@ -1,7 +1,6 @@
 #![allow(clippy::redundant_closure_call)]
 use yew::events::MouseEvent;
 use yew::prelude::*;
-use yewtil::NeqAssign;
 
 #[derive(Clone, Debug, Properties, PartialEq)]
 pub struct DeleteProps {
@@ -20,34 +19,12 @@ pub struct DeleteProps {
 /// A versatile delete cross.
 ///
 /// [https://bulma.io/documentation/elements/delete/](https://bulma.io/documentation/elements/delete/)
-pub struct Delete {
-    props: DeleteProps,
-}
-
-impl Component for Delete {
-    type Message = ();
-    type Properties = DeleteProps;
-
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
-    }
-
-    fn update(&mut self, _: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props.neq_assign(props)
-    }
-
-    fn view(&self) -> Html {
-        let mut classes = Classes::from("delete");
-        classes.push(&self.props.classes);
-        let tag = self.props.tag.clone();
-        html! {
-            <@{tag} class=classes onclick=self.props.onclick.clone()>
-                {self.props.children.clone()}
-            </@>
-        }
+#[function_component(Delete)]
+pub fn delete(props: &DeleteProps) -> Html {
+    let class = classes!("delete", props.classes.clone());
+    html! {
+        <@{props.tag.clone()} {class} onclick={props.onclick.clone()}>
+            {props.children.clone()}
+        </@>
     }
 }

--- a/src/elements/delete.rs
+++ b/src/elements/delete.rs
@@ -5,7 +5,7 @@ pub struct DeleteProps {
     #[prop_or_default]
     pub children: Children,
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
     /// The HTML tag to use for this component.
     #[prop_or_else(|| "button".into())]
     pub tag: String,
@@ -19,7 +19,7 @@ pub struct DeleteProps {
 /// [https://bulma.io/documentation/elements/delete/](https://bulma.io/documentation/elements/delete/)
 #[function_component(Delete)]
 pub fn delete(props: &DeleteProps) -> Html {
-    let class = classes!("delete", &props.classes);
+    let class = classes!("delete", props.classes.clone());
     html! {
         <@{props.tag.clone()} {class} onclick={props.onclick.clone()}>
             {props.children.clone()}

--- a/src/elements/icon.rs
+++ b/src/elements/icon.rs
@@ -27,7 +27,7 @@ pub struct IconProps {
 pub fn icon(props: &IconProps) -> Html {
     let class = classes!(
         "icon",
-        props.classes.clone(),
+        &props.classes,
         props.size.as_ref().map(|size| size.to_string()),
         props.alignment.as_ref().map(|alignment| alignment.to_string()),
     );

--- a/src/elements/icon.rs
+++ b/src/elements/icon.rs
@@ -1,6 +1,5 @@
 use yew::events::MouseEvent;
 use yew::prelude::*;
-use yewtil::NeqAssign;
 
 use crate::{Alignment, Size};
 
@@ -24,39 +23,17 @@ pub struct IconProps {
 /// A container for any type of icon font.
 ///
 /// [https://bulma.io/documentation/elements/icon/](https://bulma.io/documentation/elements/icon/)
-pub struct Icon {
-    props: IconProps,
-}
-
-impl Component for Icon {
-    type Message = ();
-    type Properties = IconProps;
-
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
-    }
-
-    fn update(&mut self, _: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props.neq_assign(props)
-    }
-
-    fn view(&self) -> Html {
-        let mut classes = Classes::from("icon");
-        classes.push(&self.props.classes);
-        if let Some(size) = &self.props.size {
-            classes.push(&size.to_string());
-        }
-        if let Some(alignment) = &self.props.alignment {
-            classes.push(&alignment.to_string());
-        }
-        html! {
-            <span class=classes onclick=self.props.onclick.clone()>
-                {self.props.children.clone()}
-            </span>
-        }
+#[function_component(Icon)]
+pub fn icon(props: &IconProps) -> Html {
+    let class = classes!(
+        "icon",
+        props.classes.clone(),
+        props.size.as_ref().map(|size| size.to_string()),
+        props.alignment.as_ref().map(|alignment| alignment.to_string()),
+    );
+    html! {
+        <span {class} onclick={props.onclick.clone()}>
+            {props.children.clone()}
+        </span>
     }
 }

--- a/src/elements/icon.rs
+++ b/src/elements/icon.rs
@@ -10,7 +10,7 @@ pub struct IconProps {
     #[prop_or_default]
     pub classes: Option<Classes>,
     /// The click handler to use for this component.
-    #[prop_or_else(Callback::noop)]
+    #[prop_or_default]
     pub onclick: Callback<MouseEvent>,
     /// The size of this component; to help prevent page "jumps" during load.
     #[prop_or_default]

--- a/src/elements/icon.rs
+++ b/src/elements/icon.rs
@@ -8,7 +8,7 @@ pub struct IconProps {
     #[prop_or_default]
     pub children: Children,
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
     /// The click handler to use for this component.
     #[prop_or_default]
     pub onclick: Callback<MouseEvent>,
@@ -27,7 +27,7 @@ pub struct IconProps {
 pub fn icon(props: &IconProps) -> Html {
     let class = classes!(
         "icon",
-        &props.classes,
+        props.classes.clone(),
         props.size.as_ref().map(|size| size.to_string()),
         props.alignment.as_ref().map(|alignment| alignment.to_string()),
     );

--- a/src/elements/image.rs
+++ b/src/elements/image.rs
@@ -1,6 +1,5 @@
 use derive_more::Display;
 use yew::prelude::*;
-use yewtil::NeqAssign;
 
 #[derive(Clone, Debug, Properties, PartialEq)]
 pub struct ImageProps {
@@ -16,37 +15,13 @@ pub struct ImageProps {
 /// A container for responsive images.
 ///
 /// [https://bulma.io/documentation/elements/image/](https://bulma.io/documentation/elements/image/)
-pub struct Image {
-    props: ImageProps,
-}
-
-impl Component for Image {
-    type Message = ();
-    type Properties = ImageProps;
-
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
-    }
-
-    fn update(&mut self, _: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props.neq_assign(props)
-    }
-
-    fn view(&self) -> Html {
-        let mut classes = Classes::from("image");
-        classes.push(&self.props.classes);
-        if let Some(size) = &self.props.size {
-            classes.push(&size.to_string());
-        }
-        html! {
-            <figure class=classes>
-                {self.props.children.clone()}
-            </figure>
-        }
+#[function_component(Image)]
+pub fn image(props: &ImageProps) -> Html {
+    let class = classes!("image", props.classes.clone(), props.size.as_ref().map(|size| size.to_string()));
+    html! {
+        <figure {class}>
+            {props.children.clone()}
+        </figure>
     }
 }
 

--- a/src/elements/image.rs
+++ b/src/elements/image.rs
@@ -17,7 +17,7 @@ pub struct ImageProps {
 /// [https://bulma.io/documentation/elements/image/](https://bulma.io/documentation/elements/image/)
 #[function_component(Image)]
 pub fn image(props: &ImageProps) -> Html {
-    let class = classes!("image", props.classes.clone(), props.size.as_ref().map(|size| size.to_string()));
+    let class = classes!("image", &props.classes, props.size.as_ref().map(|size| size.to_string()));
     html! {
         <figure {class}>
             {props.children.clone()}

--- a/src/elements/image.rs
+++ b/src/elements/image.rs
@@ -28,7 +28,7 @@ pub fn image(props: &ImageProps) -> Html {
 /// Available placeholder sizes for figures.
 ///
 /// https://bulma.io/documentation/elements/image/
-#[derive(Clone, Debug, Display, PartialEq)]
+#[derive(Clone, Debug, Display, PartialEq, Eq)]
 #[display(fmt = "is-{}")]
 pub enum ImageSize {
     #[display(fmt = "16x16")]

--- a/src/elements/image.rs
+++ b/src/elements/image.rs
@@ -6,7 +6,7 @@ pub struct ImageProps {
     #[prop_or_default]
     pub children: Children,
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
     /// The size of this component.
     #[prop_or_default]
     pub size: Option<ImageSize>,
@@ -17,7 +17,7 @@ pub struct ImageProps {
 /// [https://bulma.io/documentation/elements/image/](https://bulma.io/documentation/elements/image/)
 #[function_component(Image)]
 pub fn image(props: &ImageProps) -> Html {
-    let class = classes!("image", &props.classes, props.size.as_ref().map(|size| size.to_string()));
+    let class = classes!("image", props.classes.clone(), props.size.as_ref().map(|size| size.to_string()));
     html! {
         <figure {class}>
             {props.children.clone()}

--- a/src/elements/notification.rs
+++ b/src/elements/notification.rs
@@ -1,5 +1,4 @@
 use yew::prelude::*;
-use yewtil::NeqAssign;
 
 #[derive(Clone, Debug, Properties, PartialEq)]
 pub struct NotificationProps {
@@ -12,33 +11,12 @@ pub struct NotificationProps {
 /// Bold notification blocks, to alert your users of something.
 ///
 /// [https://bulma.io/documentation/elements/notification/](https://bulma.io/documentation/elements/notification/)
-pub struct Notification {
-    props: NotificationProps,
-}
-
-impl Component for Notification {
-    type Message = ();
-    type Properties = NotificationProps;
-
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
-    }
-
-    fn update(&mut self, _: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props.neq_assign(props)
-    }
-
-    fn view(&self) -> Html {
-        let mut classes = Classes::from("notification");
-        classes.push(&self.props.classes);
-        html! {
-            <div class=classes>
-                {self.props.children.clone()}
-            </div>
-        }
+#[function_component(Notification)]
+pub fn notification(props: &NotificationProps) -> Html {
+    let class = classes!("notification", props.classes.clone());
+    html! {
+        <div {class}>
+            {props.children.clone()}
+        </div>
     }
 }

--- a/src/elements/notification.rs
+++ b/src/elements/notification.rs
@@ -13,7 +13,7 @@ pub struct NotificationProps {
 /// [https://bulma.io/documentation/elements/notification/](https://bulma.io/documentation/elements/notification/)
 #[function_component(Notification)]
 pub fn notification(props: &NotificationProps) -> Html {
-    let class = classes!("notification", props.classes.clone());
+    let class = classes!("notification", &props.classes);
     html! {
         <div {class}>
             {props.children.clone()}

--- a/src/elements/notification.rs
+++ b/src/elements/notification.rs
@@ -5,7 +5,7 @@ pub struct NotificationProps {
     #[prop_or_default]
     pub children: Children,
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
 }
 
 /// Bold notification blocks, to alert your users of something.
@@ -13,7 +13,7 @@ pub struct NotificationProps {
 /// [https://bulma.io/documentation/elements/notification/](https://bulma.io/documentation/elements/notification/)
 #[function_component(Notification)]
 pub fn notification(props: &NotificationProps) -> Html {
-    let class = classes!("notification", &props.classes);
+    let class = classes!("notification", props.classes.clone());
     html! {
         <div {class}>
             {props.children.clone()}

--- a/src/elements/progress.rs
+++ b/src/elements/progress.rs
@@ -17,7 +17,7 @@ pub struct ProgressProps {
 /// [https://bulma.io/documentation/elements/progress/](https://bulma.io/documentation/elements/progress/)
 #[function_component(Progress)]
 pub fn progress(props: &ProgressProps) -> Html {
-    let class = classes!("progress", props.classes.clone());
+    let class = classes!("progress", &props.classes);
     let max = props.max.to_string();
     let value = props.value.to_string();
     let value_txt = format!("{}%", value);

--- a/src/elements/progress.rs
+++ b/src/elements/progress.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::redundant_closure_call)]
-
 use yew::prelude::*;
 
 #[derive(Clone, Debug, Properties, PartialEq)]

--- a/src/elements/progress.rs
+++ b/src/elements/progress.rs
@@ -1,7 +1,6 @@
 #![allow(clippy::redundant_closure_call)]
 
 use yew::prelude::*;
-use yewtil::NeqAssign;
 
 #[derive(Clone, Debug, Properties, PartialEq)]
 pub struct ProgressProps {
@@ -18,36 +17,15 @@ pub struct ProgressProps {
 /// A native HTML progress bar.
 ///
 /// [https://bulma.io/documentation/elements/progress/](https://bulma.io/documentation/elements/progress/)
-pub struct Progress {
-    props: ProgressProps,
-}
-
-impl Component for Progress {
-    type Message = ();
-    type Properties = ProgressProps;
-
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
-    }
-
-    fn update(&mut self, _: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props.neq_assign(props)
-    }
-
-    fn view(&self) -> Html {
-        let mut classes = Classes::from("progress");
-        classes.push(&self.props.classes);
-        let max = self.props.max.to_string();
-        let value = self.props.value.to_string();
-        let value_txt = html! {{format!("{}%", value)}};
-        html! {
-            <progress class=classes max=max value=value>
-                {value_txt}
-            </progress>
-        }
+#[function_component(Progress)]
+pub fn progress(props: &ProgressProps) -> Html {
+    let class = classes!("progress", props.classes.clone());
+    let max = props.max.to_string();
+    let value = props.value.to_string();
+    let value_txt = format!("{}%", value);
+    html! {
+        <progress {class} {max} {value}>
+            {value_txt}
+        </progress>
     }
 }

--- a/src/elements/progress.rs
+++ b/src/elements/progress.rs
@@ -3,7 +3,7 @@ use yew::prelude::*;
 #[derive(Clone, Debug, Properties, PartialEq)]
 pub struct ProgressProps {
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
     /// The maximum amount of progress; the 100% value.
     #[prop_or_else(|| 1.0)]
     pub max: f32,
@@ -17,7 +17,7 @@ pub struct ProgressProps {
 /// [https://bulma.io/documentation/elements/progress/](https://bulma.io/documentation/elements/progress/)
 #[function_component(Progress)]
 pub fn progress(props: &ProgressProps) -> Html {
-    let class = classes!("progress", &props.classes);
+    let class = classes!("progress", props.classes.clone());
     let max = props.max.to_string();
     let value = props.value.to_string();
     let value_txt = format!("{}%", value);

--- a/src/elements/table.rs
+++ b/src/elements/table.rs
@@ -33,7 +33,7 @@ pub struct TableProps {
 pub fn table(props: &TableProps) -> Html {
     let class = classes!(
         "table",
-        props.classes.clone(),
+        &props.classes,
         props.bordered.then(|| "is-bordered"),
         props.striped.then(|| "is-striped"),
         props.narrow.then(|| "is-narrow"),

--- a/src/elements/table.rs
+++ b/src/elements/table.rs
@@ -1,5 +1,4 @@
 use yew::prelude::*;
-use yewtil::NeqAssign;
 
 #[derive(Clone, Debug, Properties, PartialEq)]
 pub struct TableProps {
@@ -30,58 +29,30 @@ pub struct TableProps {
 /// An HTML table component.
 ///
 /// [https://bulma.io/documentation/elements/table/](https://bulma.io/documentation/elements/table/)
-pub struct Table {
-    props: TableProps,
-}
-
-impl Component for Table {
-    type Message = ();
-    type Properties = TableProps;
-
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
-    }
-
-    fn update(&mut self, _: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props.neq_assign(props)
-    }
-
-    fn view(&self) -> Html {
-        let mut classes = Classes::from("table");
-        classes.push(&self.props.classes);
-        if self.props.bordered {
-            classes.push("is-bordered");
-        }
-        if self.props.striped {
-            classes.push("is-striped");
-        }
-        if self.props.narrow {
-            classes.push("is-narrow");
-        }
-        if self.props.hoverable {
-            classes.push("is-hoverable");
-        }
-        if self.props.fullwidth {
-            classes.push("is-fullwidth");
-        }
-        if self.props.scrollable {
-            html! {
-                <div class="table-container">
-                    <table class=classes>
-                        {self.props.children.clone()}
-                    </table>
-                </div>
-            }
-        } else {
-            html! {
-                <table class=classes>
-                    {self.props.children.clone()}
+#[function_component(Table)]
+pub fn table(props: &TableProps) -> Html {
+    let class = classes!(
+        "table",
+        props.classes.clone(),
+        props.bordered.then(|| "is-bordered"),
+        props.striped.then(|| "is-striped"),
+        props.narrow.then(|| "is-narrow"),
+        props.hoverable.then(|| "is-hoverable"),
+        props.fullwidth.then(|| "is-fullwidth"),
+    );
+    if props.scrollable {
+        html! {
+            <div class="table-container">
+                <table {class}>
+                    {props.children.clone()}
                 </table>
-            }
+            </div>
+        }
+    } else {
+        html! {
+            <table {class}>
+                {props.children.clone()}
+            </table>
         }
     }
 }

--- a/src/elements/table.rs
+++ b/src/elements/table.rs
@@ -34,11 +34,11 @@ pub fn table(props: &TableProps) -> Html {
     let class = classes!(
         "table",
         &props.classes,
-        props.bordered.then(|| "is-bordered"),
-        props.striped.then(|| "is-striped"),
-        props.narrow.then(|| "is-narrow"),
-        props.hoverable.then(|| "is-hoverable"),
-        props.fullwidth.then(|| "is-fullwidth"),
+        props.bordered.then_some("is-bordered"),
+        props.striped.then_some("is-striped"),
+        props.narrow.then_some("is-narrow"),
+        props.hoverable.then_some("is-hoverable"),
+        props.fullwidth.then_some("is-fullwidth"),
     );
     if props.scrollable {
         html! {

--- a/src/elements/table.rs
+++ b/src/elements/table.rs
@@ -5,7 +5,7 @@ pub struct TableProps {
     #[prop_or_default]
     pub children: Children,
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
     /// Add borders to all the cells.
     #[prop_or_default]
     pub bordered: bool,
@@ -33,7 +33,7 @@ pub struct TableProps {
 pub fn table(props: &TableProps) -> Html {
     let class = classes!(
         "table",
-        &props.classes,
+        props.classes.clone(),
         props.bordered.then_some("is-bordered"),
         props.striped.then_some("is-striped"),
         props.narrow.then_some("is-narrow"),

--- a/src/elements/tag.rs
+++ b/src/elements/tag.rs
@@ -32,7 +32,7 @@ pub struct TagProps {
 pub fn tag(props: &TagProps) -> Html {
     let class = classes!(
         "tag",
-        props.classes.clone(),
+        &props.classes,
         props.rounded.then(|| "is-rounded"),
         props.delete.then(|| "is-delete"),
         props.size.as_ref().map(|size| size.to_string()),
@@ -63,7 +63,7 @@ pub struct TagsProps {
 /// [https://bulma.io/documentation/elements/tag/](https://bulma.io/documentation/elements/tag/)
 #[function_component(Tags)]
 pub fn tags(props: &TagsProps) -> Html {
-    let class = classes!("tags", props.classes.clone(), props.has_addons.then(|| "has-addons"));
+    let class = classes!("tags", &props.classes, props.has_addons.then(|| "has-addons"));
     html! {
         <div {class}>
             {props.children.clone()}

--- a/src/elements/tag.rs
+++ b/src/elements/tag.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::redundant_closure_call)]
-
 use yew::prelude::*;
 
 use crate::Size;

--- a/src/elements/tag.rs
+++ b/src/elements/tag.rs
@@ -1,7 +1,6 @@
 #![allow(clippy::redundant_closure_call)]
 
 use yew::prelude::*;
-use yewtil::NeqAssign;
 
 use crate::Size;
 
@@ -31,44 +30,19 @@ pub struct TagProps {
 /// A small tag label to insert anywhere.
 ///
 /// [https://bulma.io/documentation/elements/tag/](https://bulma.io/documentation/elements/tag/)
-pub struct Tag {
-    props: TagProps,
-}
-
-impl Component for Tag {
-    type Message = ();
-    type Properties = TagProps;
-
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
-    }
-
-    fn update(&mut self, _: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props.neq_assign(props)
-    }
-
-    fn view(&self) -> Html {
-        let mut classes = Classes::from("tag");
-        classes.push(&self.props.classes);
-        if self.props.rounded {
-            classes.push("is-rounded");
-        }
-        if self.props.delete {
-            classes.push("is-delete");
-        }
-        if let Some(size) = &self.props.size {
-            classes.push(&size.to_string());
-        }
-        let tag = self.props.tag.clone();
-        html! {
-            <@{tag} class=classes onclick=self.props.onclick.clone()>
-                {self.props.children.clone()}
-            </@>
-        }
+#[function_component(Tag)]
+pub fn tag(props: &TagProps) -> Html {
+    let class = classes!(
+        "tag",
+        props.classes.clone(),
+        props.rounded.then(|| "is-rounded"),
+        props.delete.then(|| "is-delete"),
+        props.size.as_ref().map(|size| size.to_string()),
+    );
+    html! {
+        <@{props.tag.clone()} {class} onclick={props.onclick.clone()}>
+            {props.children.clone()}
+        </@>
     }
 }
 
@@ -89,36 +63,12 @@ pub struct TagsProps {
 /// A container for a list of tags.
 ///
 /// [https://bulma.io/documentation/elements/tag/](https://bulma.io/documentation/elements/tag/)
-pub struct Tags {
-    props: TagsProps,
-}
-
-impl Component for Tags {
-    type Message = ();
-    type Properties = TagsProps;
-
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
-    }
-
-    fn update(&mut self, _: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props.neq_assign(props)
-    }
-
-    fn view(&self) -> Html {
-        let mut classes = Classes::from("tags");
-        classes.push(&self.props.classes);
-        if self.props.has_addons {
-            classes.push("has-addons");
-        }
-        html! {
-            <div class=classes>
-                {self.props.children.clone()}
-            </div>
-        }
+#[function_component(Tags)]
+pub fn tags(props: &TagsProps) -> Html {
+    let class = classes!("tags", props.classes.clone(), props.has_addons.then(|| "has-addons"));
+    html! {
+        <div {class}>
+            {props.children.clone()}
+        </div>
     }
 }

--- a/src/elements/tag.rs
+++ b/src/elements/tag.rs
@@ -12,7 +12,7 @@ pub struct TagProps {
     #[prop_or_else(|| "span".into())]
     pub tag: String,
     /// The click handler for this component.
-    #[prop_or_else(Callback::noop)]
+    #[prop_or_default]
     pub onclick: Callback<MouseEvent>,
     /// Make this tag rounded.
     #[prop_or_default]

--- a/src/elements/tag.rs
+++ b/src/elements/tag.rs
@@ -7,7 +7,7 @@ pub struct TagProps {
     #[prop_or_default]
     pub children: Children,
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
     /// The HTML tag to use for this component.
     #[prop_or_else(|| "span".into())]
     pub tag: String,
@@ -32,7 +32,7 @@ pub struct TagProps {
 pub fn tag(props: &TagProps) -> Html {
     let class = classes!(
         "tag",
-        &props.classes,
+        props.classes.clone(),
         props.rounded.then_some("is-rounded"),
         props.delete.then_some("is-delete"),
         props.size.as_ref().map(|size| size.to_string()),
@@ -52,7 +52,7 @@ pub struct TagsProps {
     #[prop_or_default]
     pub children: Children,
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
     /// Attach two tags together; this requires that this component wraps two `Tag` components.
     #[prop_or_default]
     pub has_addons: bool,
@@ -63,7 +63,7 @@ pub struct TagsProps {
 /// [https://bulma.io/documentation/elements/tag/](https://bulma.io/documentation/elements/tag/)
 #[function_component(Tags)]
 pub fn tags(props: &TagsProps) -> Html {
-    let class = classes!("tags", &props.classes, props.has_addons.then_some("has-addons"));
+    let class = classes!("tags", props.classes.clone(), props.has_addons.then_some("has-addons"));
     html! {
         <div {class}>
             {props.children.clone()}

--- a/src/elements/tag.rs
+++ b/src/elements/tag.rs
@@ -33,8 +33,8 @@ pub fn tag(props: &TagProps) -> Html {
     let class = classes!(
         "tag",
         &props.classes,
-        props.rounded.then(|| "is-rounded"),
-        props.delete.then(|| "is-delete"),
+        props.rounded.then_some("is-rounded"),
+        props.delete.then_some("is-delete"),
         props.size.as_ref().map(|size| size.to_string()),
     );
     html! {
@@ -63,7 +63,7 @@ pub struct TagsProps {
 /// [https://bulma.io/documentation/elements/tag/](https://bulma.io/documentation/elements/tag/)
 #[function_component(Tags)]
 pub fn tags(props: &TagsProps) -> Html {
-    let class = classes!("tags", &props.classes, props.has_addons.then(|| "has-addons"));
+    let class = classes!("tags", &props.classes, props.has_addons.then_some("has-addons"));
     html! {
         <div {class}>
             {props.children.clone()}

--- a/src/elements/title.rs
+++ b/src/elements/title.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::redundant_closure_call)]
-
 use derive_more::Display;
 use yew::prelude::*;
 

--- a/src/elements/title.rs
+++ b/src/elements/title.rs
@@ -2,7 +2,6 @@
 
 use derive_more::Display;
 use yew::prelude::*;
-use yewtil::NeqAssign;
 
 #[derive(Clone, Debug, Properties, PartialEq)]
 pub struct TitleProps {
@@ -24,41 +23,18 @@ pub struct TitleProps {
 /// A simple heading to add depth to your page.
 ///
 /// [https://bulma.io/documentation/elements/title/](https://bulma.io/documentation/elements/title/)
-pub struct Title {
-    props: TitleProps,
-}
-
-impl Component for Title {
-    type Message = ();
-    type Properties = TitleProps;
-
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
-    }
-
-    fn update(&mut self, _: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props.neq_assign(props)
-    }
-
-    fn view(&self) -> Html {
-        let mut classes = Classes::from("title");
-        classes.push(&self.props.classes);
-        if let Some(size) = &self.props.size {
-            classes.push(&size.to_string());
-        }
-        if self.props.is_spaced {
-            classes.push("is-spaced");
-        }
-        let tag = self.props.tag.clone();
-        html! {
-            <@{tag} class=classes>
-                {self.props.children.clone()}
-            </@>
-        }
+#[function_component(Title)]
+pub fn title(props: &TitleProps) -> Html {
+    let class = classes!(
+        "title",
+        props.classes.clone(),
+        props.size.as_ref().map(|size| size.to_string()),
+        props.is_spaced.then(|| "is-spaced"),
+    );
+    html! {
+        <@{props.tag.clone()} {class}>
+            {props.children.clone()}
+        </@>
     }
 }
 
@@ -82,38 +58,13 @@ pub struct SubtitleProps {
 /// A simple heading to add depth to your page.
 ///
 /// [https://bulma.io/documentation/elements/title/](https://bulma.io/documentation/elements/title/)
-pub struct Subtitle {
-    props: SubtitleProps,
-}
-
-impl Component for Subtitle {
-    type Message = ();
-    type Properties = SubtitleProps;
-
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
-    }
-
-    fn update(&mut self, _: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props.neq_assign(props)
-    }
-
-    fn view(&self) -> Html {
-        let mut classes = Classes::from("subtitle");
-        classes.push(&self.props.classes);
-        if let Some(size) = &self.props.size {
-            classes.push(&size.to_string());
-        }
-        let tag = self.props.tag.clone();
-        html! {
-            <@{tag} class=classes>
-                {self.props.children.clone()}
-            </@>
-        }
+#[function_component(Subtitle)]
+pub fn subtitle(props: &SubtitleProps) -> Html {
+    let class = classes!("subtitle", props.classes.clone(), props.size.as_ref().map(|size| size.to_string()));
+    html! {
+        <@{props.tag.clone()} {class}>
+            {props.children.clone()}
+        </@>
     }
 }
 

--- a/src/elements/title.rs
+++ b/src/elements/title.rs
@@ -25,7 +25,7 @@ pub struct TitleProps {
 pub fn title(props: &TitleProps) -> Html {
     let class = classes!(
         "title",
-        props.classes.clone(),
+        &props.classes,
         props.size.as_ref().map(|size| size.to_string()),
         props.is_spaced.then(|| "is-spaced"),
     );
@@ -58,7 +58,7 @@ pub struct SubtitleProps {
 /// [https://bulma.io/documentation/elements/title/](https://bulma.io/documentation/elements/title/)
 #[function_component(Subtitle)]
 pub fn subtitle(props: &SubtitleProps) -> Html {
-    let class = classes!("subtitle", props.classes.clone(), props.size.as_ref().map(|size| size.to_string()));
+    let class = classes!("subtitle", &props.classes, props.size.as_ref().map(|size| size.to_string()));
     html! {
         <@{props.tag.clone()} {class}>
             {props.children.clone()}

--- a/src/elements/title.rs
+++ b/src/elements/title.rs
@@ -27,7 +27,7 @@ pub fn title(props: &TitleProps) -> Html {
         "title",
         &props.classes,
         props.size.as_ref().map(|size| size.to_string()),
-        props.is_spaced.then(|| "is-spaced"),
+        props.is_spaced.then_some("is-spaced"),
     );
     html! {
         <@{props.tag.clone()} {class}>
@@ -69,7 +69,7 @@ pub fn subtitle(props: &SubtitleProps) -> Html {
 /// The six sizes available for titles & subtitles.
 ///
 /// https://bulma.io/documentation/elements/title/#sizes
-#[derive(Clone, Debug, Display, PartialEq)]
+#[derive(Clone, Debug, Display, PartialEq, Eq)]
 #[display(fmt = "is-{}")]
 pub enum HeaderSize {
     #[display(fmt = "1")]

--- a/src/elements/title.rs
+++ b/src/elements/title.rs
@@ -6,7 +6,7 @@ pub struct TitleProps {
     #[prop_or_default]
     pub children: Children,
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
     /// The HTML tag to use for this component.
     #[prop_or_else(|| "h3".into())]
     pub tag: String,
@@ -25,7 +25,7 @@ pub struct TitleProps {
 pub fn title(props: &TitleProps) -> Html {
     let class = classes!(
         "title",
-        &props.classes,
+        props.classes.clone(),
         props.size.as_ref().map(|size| size.to_string()),
         props.is_spaced.then_some("is-spaced"),
     );
@@ -44,7 +44,7 @@ pub struct SubtitleProps {
     #[prop_or_default]
     pub children: Children,
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
     /// The HTML tag to use for this component.
     #[prop_or_else(|| "h3".into())]
     pub tag: String,
@@ -58,7 +58,7 @@ pub struct SubtitleProps {
 /// [https://bulma.io/documentation/elements/title/](https://bulma.io/documentation/elements/title/)
 #[function_component(Subtitle)]
 pub fn subtitle(props: &SubtitleProps) -> Html {
-    let class = classes!("subtitle", &props.classes, props.size.as_ref().map(|size| size.to_string()));
+    let class = classes!("subtitle", props.classes.clone(), props.size.as_ref().map(|size| size.to_string()));
     html! {
         <@{props.tag.clone()} {class}>
             {props.children.clone()}

--- a/src/form/checkbox.rs
+++ b/src/form/checkbox.rs
@@ -26,7 +26,7 @@ pub struct CheckboxProps {
 /// component via callback.
 #[function_component(Checkbox)]
 pub fn checkbox(props: &CheckboxProps) -> Html {
-    let class = classes!("checkbox", props.classes.clone());
+    let class = classes!("checkbox", &props.classes);
     let checked = props.checked;
     html! {
         <label {class} disabled={props.disabled}>

--- a/src/form/checkbox.rs
+++ b/src/form/checkbox.rs
@@ -1,5 +1,4 @@
 use yew::prelude::*;
-use yewtil::NeqAssign;
 
 #[derive(Clone, Debug, Properties, PartialEq)]
 pub struct CheckboxProps {
@@ -25,43 +24,20 @@ pub struct CheckboxProps {
 /// All YBC form components are controlled components. This means that the value of the field must
 /// be provided from a parent component, and changes to this component are propagated to the parent
 /// component via callback.
-pub struct Checkbox {
-    props: CheckboxProps,
-    link: ComponentLink<Self>,
-}
-
-impl Component for Checkbox {
-    type Message = bool;
-    type Properties = CheckboxProps;
-
-    fn create(props: Self::Properties, link: ComponentLink<Self>) -> Self {
-        Self { props, link }
-    }
-
-    fn update(&mut self, msg: Self::Message) -> ShouldRender {
-        self.props.update.emit(msg);
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props.neq_assign(props)
-    }
-
-    fn view(&self) -> Html {
-        let mut classes = Classes::from("checkbox");
-        classes.push(&self.props.classes);
-        let checked = self.props.checked;
-        html! {
-            <label class=classes disabled=self.props.disabled>
-                <input
-                    type="checkbox"
-                    checked=self.props.checked
-                    name=self.props.name.clone()
-                    onclick=self.link.callback(move |_| !checked)
-                    disabled=self.props.disabled
-                    />
-                {self.props.children.clone()}
-            </label>
-        }
+#[function_component(Checkbox)]
+pub fn checkbox(props: &CheckboxProps) -> Html {
+    let class = classes!("checkbox", props.classes.clone());
+    let checked = props.checked;
+    html! {
+        <label {class} disabled={props.disabled}>
+            <input
+                type="checkbox"
+                checked={props.checked}
+                name={props.name.clone()}
+                onclick={props.update.reform(move |_| !checked)}
+                disabled={props.disabled}
+                />
+            {props.children.clone()}
+        </label>
     }
 }

--- a/src/form/checkbox.rs
+++ b/src/form/checkbox.rs
@@ -11,7 +11,7 @@ pub struct CheckboxProps {
     #[prop_or_default]
     pub children: Children,
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
     /// Disable this component.
     #[prop_or_default]
     pub disabled: bool,
@@ -26,7 +26,7 @@ pub struct CheckboxProps {
 /// component via callback.
 #[function_component(Checkbox)]
 pub fn checkbox(props: &CheckboxProps) -> Html {
-    let class = classes!("checkbox", &props.classes);
+    let class = classes!("checkbox", props.classes.clone());
     let checked = props.checked;
     html! {
         <label {class} disabled={props.disabled}>

--- a/src/form/control.rs
+++ b/src/form/control.rs
@@ -19,7 +19,7 @@ pub struct ControlProps {
 /// [https://bulma.io/documentation/form/general/](https://bulma.io/documentation/form/general/)
 #[function_component(Control)]
 pub fn control(props: &ControlProps) -> Html {
-    let class = classes!("control", props.classes.clone(), props.expanded.then(|| "is-expanded"));
+    let class = classes!("control", &props.classes, props.expanded.then(|| "is-expanded"));
     html! {
         <@{props.tag.clone()} {class}>
             {props.children.clone()}

--- a/src/form/control.rs
+++ b/src/form/control.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::redundant_closure_call)]
-
 use yew::prelude::*;
 
 #[derive(Clone, Debug, Properties, PartialEq)]

--- a/src/form/control.rs
+++ b/src/form/control.rs
@@ -1,7 +1,6 @@
 #![allow(clippy::redundant_closure_call)]
 
 use yew::prelude::*;
-use yewtil::NeqAssign;
 
 #[derive(Clone, Debug, Properties, PartialEq)]
 pub struct ControlProps {
@@ -20,37 +19,12 @@ pub struct ControlProps {
 /// A container with which you can wrap the form controls.
 ///
 /// [https://bulma.io/documentation/form/general/](https://bulma.io/documentation/form/general/)
-pub struct Control {
-    props: ControlProps,
-}
-
-impl Component for Control {
-    type Message = ();
-    type Properties = ControlProps;
-
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
-    }
-
-    fn update(&mut self, _: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props.neq_assign(props)
-    }
-
-    fn view(&self) -> Html {
-        let mut classes = Classes::from("control");
-        classes.push(&self.props.classes);
-        if self.props.expanded {
-            classes.push("is-expanded");
-        }
-        let tag = self.props.tag.clone();
-        html! {
-            <@{tag} class=classes>
-                {self.props.children.clone()}
-            </@>
-        }
+#[function_component(Control)]
+pub fn control(props: &ControlProps) -> Html {
+    let class = classes!("control", props.classes.clone(), props.expanded.then(|| "is-expanded"));
+    html! {
+        <@{props.tag.clone()} {class}>
+            {props.children.clone()}
+        </@>
     }
 }

--- a/src/form/control.rs
+++ b/src/form/control.rs
@@ -19,7 +19,7 @@ pub struct ControlProps {
 /// [https://bulma.io/documentation/form/general/](https://bulma.io/documentation/form/general/)
 #[function_component(Control)]
 pub fn control(props: &ControlProps) -> Html {
-    let class = classes!("control", &props.classes, props.expanded.then(|| "is-expanded"));
+    let class = classes!("control", &props.classes, props.expanded.then_some("is-expanded"));
     html! {
         <@{props.tag.clone()} {class}>
             {props.children.clone()}

--- a/src/form/control.rs
+++ b/src/form/control.rs
@@ -5,7 +5,7 @@ pub struct ControlProps {
     #[prop_or_default]
     pub children: Children,
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
     /// The HTML tag to use for this component.
     #[prop_or_else(|| "div".into())]
     pub tag: String,
@@ -19,7 +19,7 @@ pub struct ControlProps {
 /// [https://bulma.io/documentation/form/general/](https://bulma.io/documentation/form/general/)
 #[function_component(Control)]
 pub fn control(props: &ControlProps) -> Html {
-    let class = classes!("control", &props.classes, props.expanded.then_some("is-expanded"));
+    let class = classes!("control", props.classes.clone(), props.expanded.then_some("is-expanded"));
     html! {
         <@{props.tag.clone()} {class}>
             {props.children.clone()}

--- a/src/form/field.rs
+++ b/src/form/field.rs
@@ -1,6 +1,5 @@
 use derive_more::Display;
 use yew::prelude::*;
-use yewtil::NeqAssign;
 
 #[derive(Clone, Debug, Properties, PartialEq)]
 pub struct FieldProps {
@@ -50,114 +49,76 @@ pub struct FieldProps {
 }
 
 /// A container for form controls
-pub struct Field {
-    props: FieldProps,
-}
+#[function_component(Field)]
+pub fn field(props: &FieldProps) -> Html {
+    let class = classes!(
+        "field",
+        props.classes.clone(),
+        props.icons_left.then(|| "has-icons-left"),
+        props.icons_right.then(|| "has-icons-right"),
+        props.addons.then(|| "has-addons"),
+        props.grouped.then(|| "is-grouped"),
+        props.multiline.then(|| "is-multiline"),
+        props.addons_align.as_ref().map(|align| align.to_string()),
+        props.grouped_align.as_ref().map(|align| align.to_string()),
+    );
 
-impl Component for Field {
-    type Message = ();
-    type Properties = FieldProps;
-
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
-    }
-
-    fn update(&mut self, _: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props.neq_assign(props)
-    }
-
-    fn view(&self) -> Html {
-        let mut classes = Classes::from("field");
-        classes.push(&self.props.classes);
-        if self.props.icons_left {
-            classes.push("has-icons-left");
-        }
-        if self.props.icons_right {
-            classes.push("has-icons-right");
-        }
-        if self.props.addons {
-            classes.push("has-addons");
-        }
-        if let Some(align) = &self.props.addons_align {
-            classes.push(&align.to_string());
-        }
-        if self.props.grouped {
-            classes.push("is-grouped");
-        }
-        if let Some(align) = &self.props.grouped_align {
-            classes.push(&align.to_string());
-        }
-        if self.props.multiline {
-            classes.push("is-grouped-multiline");
-        }
-
-        // Build the label if label content is provided.
-        let label = match &self.props.label {
-            Some(label_content) => match &self.props.label_classes {
-                Some(label_classes_str) => {
-                    let mut label_classes = label_classes_str.clone();
-                    if self.props.horizontal {
-                        label_classes.push("field-label");
-                        html! {
-                            <div class=label_classes>
-                                <label class="label">{label_content.clone()}</label>
-                            </div>
-                        }
-                    } else {
-                        label_classes.push("label");
-                        html! {<label class=label_classes>{label_content.clone()}</label>}
+    // Build the label if label content is provided.
+    let label = match &props.label {
+        Some(label_content) => match &props.label_classes {
+            Some(label_classes_str) => {
+                let mut label_classes = label_classes_str.clone();
+                if props.horizontal {
+                    label_classes.push("field-label");
+                    html! {
+                        <div class={label_classes}>
+                            <label class="label">{label_content.clone()}</label>
+                        </div>
                     }
+                } else {
+                    label_classes.push("label");
+                    html! {<label class={label_classes}>{label_content.clone()}</label>}
                 }
-                None => {
-                    if self.props.horizontal {
-                        html! {<div class="field-label"><label class="label">{label_content.clone()}</label></div>}
-                    } else {
-                        html! {<label class="label">{label_content.clone()}</label>}
-                    }
+            }
+            None => {
+                if props.horizontal {
+                    html! {<div class="field-label"><label class="label">{label_content.clone()}</label></div>}
+                } else {
+                    html! {<label class="label">{label_content.clone()}</label>}
                 }
-            },
-            None => html! {},
-        };
+            }
+        },
+        None => html! {},
+    };
 
-        // Build the help label if present.
-        let help = match &self.props.help {
-            Some(help_content) => match &self.props.help_classes {
-                Some(help_classes_str) => {
-                    let mut help_classes = help_classes_str.clone();
-                    help_classes.push("help");
-                    if self.props.help_has_error {
-                        help_classes.push("is-danger");
-                    }
-                    html! {<label class=help_classes>{help_content.clone()}</label>}
-                }
-                None => {
-                    let mut help_classes = Classes::from("help");
-                    if self.props.help_has_error {
-                        help_classes.push("is-danger");
-                    }
-                    html! {<label class=help_classes>{help_content.clone()}</label>}
-                }
-            },
-            None => html! {},
-        };
+    // Build the help label if present.
+    let help = match &props.help {
+        Some(help_content) => match &props.help_classes {
+            Some(help_classes_str) => {
+                let class = classes!("help", help_classes_str.clone(), props.help_has_error.then(|| "is-danger"));
+                html! {<label {class}>{help_content.clone()}</label>}
+            }
+            None => {
+                let class = classes!("help", props.help_has_error.then(|| "is-danger"));
+                html! {<label {class}>{help_content.clone()}</label>}
+            }
+        },
+        None => html! {},
+    };
 
-        // Build the body section.
-        let mut body = html! {<>{self.props.children.clone()}</>};
-        if self.props.horizontal {
-            body = html! {<div class="field-body">{body}</div>}
-        }
+    // Build the body section.
+    let body = if props.horizontal {
+        html! {<div class="field-body">{props.children.clone()}</div>}
+    } else {
+        html! {<>{props.children.clone()}</>}
+    };
 
-        html! {
-            <div class=classes>
-                {label}
-                {body}
-                {help}
-            </div>
-        }
+    html! {
+        <div {class}>
+            {label}
+            {body}
+            {help}
+        </div>
     }
 }
 

--- a/src/form/field.rs
+++ b/src/form/field.rs
@@ -53,7 +53,7 @@ pub struct FieldProps {
 pub fn field(props: &FieldProps) -> Html {
     let class = classes!(
         "field",
-        props.classes.clone(),
+        &props.classes,
         props.icons_left.then(|| "has-icons-left"),
         props.icons_right.then(|| "has-icons-right"),
         props.addons.then(|| "has-addons"),

--- a/src/form/field.rs
+++ b/src/form/field.rs
@@ -54,11 +54,11 @@ pub fn field(props: &FieldProps) -> Html {
     let class = classes!(
         "field",
         &props.classes,
-        props.icons_left.then(|| "has-icons-left"),
-        props.icons_right.then(|| "has-icons-right"),
-        props.addons.then(|| "has-addons"),
-        props.grouped.then(|| "is-grouped"),
-        props.multiline.then(|| "is-multiline"),
+        props.icons_left.then_some("has-icons-left"),
+        props.icons_right.then_some("has-icons-right"),
+        props.addons.then_some("has-addons"),
+        props.grouped.then_some("is-grouped"),
+        props.multiline.then_some("is-multiline"),
         props.addons_align.as_ref().map(|align| align.to_string()),
         props.grouped_align.as_ref().map(|align| align.to_string()),
     );
@@ -95,11 +95,11 @@ pub fn field(props: &FieldProps) -> Html {
     let help = match &props.help {
         Some(help_content) => match &props.help_classes {
             Some(help_classes_str) => {
-                let class = classes!("help", help_classes_str.clone(), props.help_has_error.then(|| "is-danger"));
+                let class = classes!("help", help_classes_str.clone(), props.help_has_error.then_some("is-danger"));
                 html! {<label {class}>{help_content.clone()}</label>}
             }
             None => {
-                let class = classes!("help", props.help_has_error.then(|| "is-danger"));
+                let class = classes!("help", props.help_has_error.then_some("is-danger"));
                 html! {<label {class}>{help_content.clone()}</label>}
             }
         },
@@ -125,7 +125,7 @@ pub fn field(props: &FieldProps) -> Html {
 /// The two alignment options available for field addons.
 ///
 /// https://bulma.io/documentation/form/general/
-#[derive(Clone, Debug, Display, PartialEq)]
+#[derive(Clone, Debug, Display, PartialEq, Eq)]
 #[display(fmt = "has-addons-{}")]
 pub enum AddonsAlign {
     #[display(fmt = "centered")]
@@ -137,7 +137,7 @@ pub enum AddonsAlign {
 /// The two alignment options available for grouped field controls.
 ///
 /// https://bulma.io/documentation/form/general/
-#[derive(Clone, Debug, Display, PartialEq)]
+#[derive(Clone, Debug, Display, PartialEq, Eq)]
 #[display(fmt = "is-grouped-{}")]
 pub enum GroupedAlign {
     #[display(fmt = "centered")]
@@ -149,7 +149,7 @@ pub enum GroupedAlign {
 /// The three sizes available for horizontal field labels.
 ///
 /// https://bulma.io/documentation/form/general/#horizontal-form
-#[derive(Clone, Debug, Display, PartialEq)]
+#[derive(Clone, Debug, Display, PartialEq, Eq)]
 #[display(fmt = "is-{}")]
 pub enum LabelSize {
     #[display(fmt = "small")]

--- a/src/form/field.rs
+++ b/src/form/field.rs
@@ -6,19 +6,19 @@ pub struct FieldProps {
     #[prop_or_default]
     pub children: Children,
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
     /// A text label for the field.
     #[prop_or_default]
     pub label: Option<String>,
     /// Extra classes for the label container.
     #[prop_or_default]
-    pub label_classes: Option<Classes>,
+    pub label_classes: Classes,
     /// A help message for the field.
     #[prop_or_default]
     pub help: Option<String>,
     /// Extra classes for the help message container.
     #[prop_or_default]
-    pub help_classes: Option<Classes>,
+    pub help_classes: Classes,
     /// A convenience bool to add the `is-danger` class to the help classes when `true`.
     #[prop_or_default]
     pub help_has_error: bool,
@@ -53,7 +53,7 @@ pub struct FieldProps {
 pub fn field(props: &FieldProps) -> Html {
     let class = classes!(
         "field",
-        &props.classes,
+        props.classes.clone(),
         props.icons_left.then_some("has-icons-left"),
         props.icons_right.then_some("has-icons-right"),
         props.addons.then_some("has-addons"),
@@ -65,9 +65,15 @@ pub fn field(props: &FieldProps) -> Html {
 
     // Build the label if label content is provided.
     let label = match &props.label {
-        Some(label_content) => match &props.label_classes {
-            Some(label_classes_str) => {
-                let mut label_classes = label_classes_str.clone();
+        Some(label_content) => {
+            if props.label_classes.is_empty() {
+                if props.horizontal {
+                    html! {<div class="field-label"><label class="label">{label_content.clone()}</label></div>}
+                } else {
+                    html! {<label class="label">{label_content.clone()}</label>}
+                }
+            } else {
+                let mut label_classes = props.label_classes.clone();
                 if props.horizontal {
                     label_classes.push("field-label");
                     html! {
@@ -80,29 +86,21 @@ pub fn field(props: &FieldProps) -> Html {
                     html! {<label class={label_classes}>{label_content.clone()}</label>}
                 }
             }
-            None => {
-                if props.horizontal {
-                    html! {<div class="field-label"><label class="label">{label_content.clone()}</label></div>}
-                } else {
-                    html! {<label class="label">{label_content.clone()}</label>}
-                }
-            }
-        },
+        }
         None => html! {},
     };
 
     // Build the help label if present.
     let help = match &props.help {
-        Some(help_content) => match &props.help_classes {
-            Some(help_classes_str) => {
-                let class = classes!("help", help_classes_str.clone(), props.help_has_error.then_some("is-danger"));
-                html! {<label {class}>{help_content.clone()}</label>}
-            }
-            None => {
+        Some(help_content) => {
+            if props.help_classes.is_empty() {
                 let class = classes!("help", props.help_has_error.then_some("is-danger"));
                 html! {<label {class}>{help_content.clone()}</label>}
+            } else {
+                let class = classes!("help", props.help_classes.clone(), props.help_has_error.then_some("is-danger"));
+                html! {<label {class}>{help_content.clone()}</label>}
             }
-        },
+        }
         None => html! {},
     };
 

--- a/src/form/file.rs
+++ b/src/form/file.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::redundant_closure_call)]
 
-use wasm_bindgen::{JsCast, UnwrapThrowExt};
+use wasm_bindgen::UnwrapThrowExt;
 use web_sys::{File as SysFile, HtmlInputElement};
 use yew::prelude::*;
 
@@ -74,8 +74,7 @@ pub fn file(props: &FileProps) -> Html {
         .map(|file| html! {<span class="file-name">{file.name()}</span>})
         .collect::<Vec<_>>();
     let onchange = props.update.reform(|ev: web_sys::Event| {
-        let target = ev.target().expect_throw("event should have a target");
-        let input: HtmlInputElement = target.dyn_into().expect_throw("event target should be an input");
+        let input: HtmlInputElement = ev.target_dyn_into().expect_throw("event target should be an input");
         let list = input.files().expect_throw("input should have a file list");
         (0..list.length())
             .into_iter()

--- a/src/form/file.rs
+++ b/src/form/file.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::redundant_closure_call)]
-
 use wasm_bindgen::UnwrapThrowExt;
 use web_sys::{File as SysFile, HtmlInputElement};
 use yew::prelude::*;

--- a/src/form/file.rs
+++ b/src/form/file.rs
@@ -58,7 +58,7 @@ pub struct FileProps {
 pub fn file(props: &FileProps) -> Html {
     let class = classes!(
         "file",
-        props.classes.clone(),
+        &props.classes,
         props.has_name.is_some().then(|| "has-name"),
         props.right.then(|| "is-right"),
         props.fullwidth.then(|| "is-fullwidth"),

--- a/src/form/file.rs
+++ b/src/form/file.rs
@@ -1,9 +1,8 @@
 #![allow(clippy::redundant_closure_call)]
 
-use web_sys::File as SysFile;
-use yew::events::ChangeData;
+use wasm_bindgen::{JsCast, UnwrapThrowExt};
+use web_sys::{File as SysFile, HtmlInputElement};
 use yew::prelude::*;
-use yewtil::NeqAssign;
 
 use crate::{Alignment, Size};
 
@@ -57,81 +56,52 @@ pub struct FileProps {
 /// All YBC form components are controlled components. This means that the value of the field must
 /// be provided from a parent component, and changes to this component are propagated to the parent
 /// component via callback.
-pub struct File {
-    props: FileProps,
-    link: ComponentLink<Self>,
-}
-
-impl Component for File {
-    type Message = Vec<SysFile>;
-    type Properties = FileProps;
-
-    fn create(props: Self::Properties, link: ComponentLink<Self>) -> Self {
-        Self { props, link }
-    }
-
-    fn update(&mut self, msg: Self::Message) -> ShouldRender {
-        self.props.update.emit(msg);
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props.neq_assign(props)
-    }
-
-    fn view(&self) -> Html {
-        let mut classes = Classes::from("file");
-        classes.push(&self.props.classes);
-        if self.props.has_name.is_some() {
-            classes.push("has-name");
-        }
-        if self.props.right {
-            classes.push("is-right");
-        }
-        if self.props.fullwidth {
-            classes.push("is-fullwidth");
-        }
-        if self.props.boxed {
-            classes.push("is-boxed");
-        }
-        if let Some(size) = &self.props.size {
-            classes.push(&size.to_string());
-        }
-        if let Some(alignment) = &self.props.alignment {
-            classes.push(&alignment.to_string());
-        }
-        let filenames = self
-            .props
-            .files
-            .iter()
-            .map(|file| html! {<span class="file-name">{file.name()}</span>})
-            .collect::<Vec<_>>();
-        html! {
-            <div class=classes>
-                <label class="file-label">
-                    <input
-                        type="file"
-                        class="file-input"
-                        name=self.props.name.clone()
-                        multiple=self.props.multiple
-                        onchange=self.link.callback(|data: ChangeData| match data {
-                            ChangeData::Files(list) => (0..list.length()).into_iter()
-                                .filter_map(|idx| list.item(idx))
-                                .collect::<Vec<_>>(),
-                            _ => unreachable!("invariant violation: received non-file change event from a file input element"),
-                        })
-                        />
-                    <span class="file-cta">
-                        <span class="file-icon">
-                            {self.props.selector_icon.clone()}
-                        </span>
-                        <span class="file-label">
-                            {self.props.selector_label.clone()}
-                        </span>
+#[function_component(File)]
+pub fn file(props: &FileProps) -> Html {
+    let class = classes!(
+        "file",
+        props.classes.clone(),
+        props.has_name.is_some().then(|| "has-name"),
+        props.right.then(|| "is-right"),
+        props.fullwidth.then(|| "is-fullwidth"),
+        props.boxed.then(|| "is-boxed"),
+        props.size.as_ref().map(|size| size.to_string()),
+        props.alignment.as_ref().map(|alignment| alignment.to_string()),
+    );
+    let filenames = props
+        .files
+        .iter()
+        .map(|file| html! {<span class="file-name">{file.name()}</span>})
+        .collect::<Vec<_>>();
+    let onchange = props.update.reform(|ev: web_sys::Event| {
+        let target = ev.target().expect_throw("event should have a target");
+        let input: HtmlInputElement = target.dyn_into().expect_throw("event target should be an input");
+        let list = input.files().expect_throw("input should have a file list");
+        (0..list.length())
+            .into_iter()
+            .filter_map(|idx| list.item(idx))
+            .collect::<Vec<_>>()
+    });
+    html! {
+        <div {class}>
+            <label class="file-label">
+                <input
+                    type="file"
+                    class="file-input"
+                    name={props.name.clone()}
+                    multiple={props.multiple}
+                    {onchange}
+                    />
+                <span class="file-cta">
+                    <span class="file-icon">
+                        {props.selector_icon.clone()}
                     </span>
-                    {filenames}
-                </label>
-            </div>
-        }
+                    <span class="file-label">
+                        {props.selector_label.clone()}
+                    </span>
+                </span>
+                {filenames}
+            </label>
+        </div>
     }
 }

--- a/src/form/file.rs
+++ b/src/form/file.rs
@@ -59,10 +59,10 @@ pub fn file(props: &FileProps) -> Html {
     let class = classes!(
         "file",
         &props.classes,
-        props.has_name.is_some().then(|| "has-name"),
-        props.right.then(|| "is-right"),
-        props.fullwidth.then(|| "is-fullwidth"),
-        props.boxed.then(|| "is-boxed"),
+        props.has_name.is_some().then_some("has-name"),
+        props.right.then_some("is-right"),
+        props.fullwidth.then_some("is-fullwidth"),
+        props.boxed.then_some("is-boxed"),
         props.size.as_ref().map(|size| size.to_string()),
         props.alignment.as_ref().map(|alignment| alignment.to_string()),
     );

--- a/src/form/file.rs
+++ b/src/form/file.rs
@@ -21,7 +21,7 @@ pub struct FileProps {
     pub selector_icon: Html,
 
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
     /// An option to control if file names will be displayed; if a value is provided, then the
     /// `has-name` class will be added to this form element and the given value will be used as a
     /// placeholder until files are selected.
@@ -58,7 +58,7 @@ pub struct FileProps {
 pub fn file(props: &FileProps) -> Html {
     let class = classes!(
         "file",
-        &props.classes,
+        props.classes.clone(),
         props.has_name.is_some().then_some("has-name"),
         props.right.then_some("is-right"),
         props.fullwidth.then_some("is-fullwidth"),

--- a/src/form/input.rs
+++ b/src/form/input.rs
@@ -1,9 +1,9 @@
 #![allow(clippy::redundant_closure_call)]
 
 use derive_more::Display;
-use yew::events::InputData;
+use wasm_bindgen::{JsCast, UnwrapThrowExt};
+use web_sys::HtmlInputElement;
 use yew::prelude::*;
-use yewtil::NeqAssign;
 
 use crate::Size;
 
@@ -51,55 +51,32 @@ pub struct InputProps {
 /// All YBC form components are controlled components. This means that the value of the field must
 /// be provided from a parent component, and changes to this component are propagated to the parent
 /// component via callback.
-pub struct Input {
-    props: InputProps,
-    link: ComponentLink<Self>,
-}
-
-impl Component for Input {
-    type Message = String;
-    type Properties = InputProps;
-
-    fn create(props: Self::Properties, link: ComponentLink<Self>) -> Self {
-        Self { props, link }
-    }
-
-    fn update(&mut self, msg: Self::Message) -> ShouldRender {
-        self.props.update.emit(msg);
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props.neq_assign(props)
-    }
-
-    fn view(&self) -> Html {
-        let mut classes = Classes::from("input");
-        classes.push(&self.props.classes);
-        if let Some(size) = &self.props.size {
-            classes.push(&size.to_string());
-        }
-        if self.props.rounded {
-            classes.push("is-rounded");
-        }
-        if self.props.loading {
-            classes.push("is-loading");
-        }
-        if self.props.r#static {
-            classes.push("is-static");
-        }
-        html! {
-            <input
-                name=self.props.name.clone()
-                value=self.props.value.clone()
-                oninput=self.link.callback(|input: InputData| input.value)
-                class=classes
-                type=self.props.r#type.to_string()
-                placeholder=self.props.placeholder.clone()
-                disabled=self.props.disabled
-                readonly=self.props.readonly
-                />
-        }
+#[function_component(Input)]
+pub fn input(props: &InputProps) -> Html {
+    let class = classes!(
+        "input",
+        props.classes.clone(),
+        props.size.as_ref().map(|size| size.to_string()),
+        props.rounded.then(|| "is-rounded"),
+        props.loading.then(|| "is-loading"),
+        props.r#static.then(|| "is-static"),
+    );
+    let oninput = props.update.reform(|ev: web_sys::InputEvent| {
+        let target = ev.target().expect_throw("event should have a target");
+        let input: HtmlInputElement = target.dyn_into().expect_throw("event target should be an input");
+        input.value()
+    });
+    html! {
+        <input
+            name={props.name.clone()}
+            value={props.value.clone()}
+            {oninput}
+            {class}
+            type={props.r#type.to_string()}
+            placeholder={props.placeholder.clone()}
+            disabled={props.disabled}
+            readonly={props.readonly}
+            />
     }
 }
 

--- a/src/form/input.rs
+++ b/src/form/input.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::redundant_closure_call)]
 
 use derive_more::Display;
-use wasm_bindgen::{JsCast, UnwrapThrowExt};
+use wasm_bindgen::UnwrapThrowExt;
 use web_sys::HtmlInputElement;
 use yew::prelude::*;
 
@@ -62,8 +62,7 @@ pub fn input(props: &InputProps) -> Html {
         props.r#static.then(|| "is-static"),
     );
     let oninput = props.update.reform(|ev: web_sys::InputEvent| {
-        let target = ev.target().expect_throw("event should have a target");
-        let input: HtmlInputElement = target.dyn_into().expect_throw("event target should be an input");
+        let input: HtmlInputElement = ev.target_dyn_into().expect_throw("event target should be an input");
         input.value()
     });
     html! {

--- a/src/form/input.rs
+++ b/src/form/input.rs
@@ -53,7 +53,7 @@ pub struct InputProps {
 pub fn input(props: &InputProps) -> Html {
     let class = classes!(
         "input",
-        props.classes.clone(),
+        &props.classes,
         props.size.as_ref().map(|size| size.to_string()),
         props.rounded.then(|| "is-rounded"),
         props.loading.then(|| "is-loading"),

--- a/src/form/input.rs
+++ b/src/form/input.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::redundant_closure_call)]
-
 use derive_more::Display;
 use wasm_bindgen::UnwrapThrowExt;
 use web_sys::HtmlInputElement;

--- a/src/form/input.rs
+++ b/src/form/input.rs
@@ -15,7 +15,7 @@ pub struct InputProps {
     pub update: Callback<String>,
 
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
     /// The input type of this component.
     #[prop_or_else(|| InputType::Text)]
     pub r#type: InputType,
@@ -53,7 +53,7 @@ pub struct InputProps {
 pub fn input(props: &InputProps) -> Html {
     let class = classes!(
         "input",
-        &props.classes,
+        props.classes.clone(),
         props.size.as_ref().map(|size| size.to_string()),
         props.rounded.then_some("is-rounded"),
         props.loading.then_some("is-loading"),

--- a/src/form/input.rs
+++ b/src/form/input.rs
@@ -55,9 +55,9 @@ pub fn input(props: &InputProps) -> Html {
         "input",
         &props.classes,
         props.size.as_ref().map(|size| size.to_string()),
-        props.rounded.then(|| "is-rounded"),
-        props.loading.then(|| "is-loading"),
-        props.r#static.then(|| "is-static"),
+        props.rounded.then_some("is-rounded"),
+        props.loading.then_some("is-loading"),
+        props.r#static.then_some("is-static"),
     );
     let oninput = props.update.reform(|ev: web_sys::InputEvent| {
         let input: HtmlInputElement = ev.target_dyn_into().expect_throw("event target should be an input");
@@ -80,7 +80,7 @@ pub fn input(props: &InputProps) -> Html {
 /// The 4 allowed types for an input component.
 ///
 /// https://bulma.io/documentation/form/input/
-#[derive(Clone, Debug, Display, PartialEq)]
+#[derive(Clone, Debug, Display, PartialEq, Eq)]
 pub enum InputType {
     #[display(fmt = "text")]
     Text,

--- a/src/form/radio.rs
+++ b/src/form/radio.rs
@@ -1,6 +1,6 @@
-use yew::events::InputData;
+use wasm_bindgen::{JsCast, UnwrapThrowExt};
+use web_sys::HtmlInputElement;
 use yew::prelude::*;
-use yewtil::NeqAssign;
 
 #[derive(Clone, Debug, Properties, PartialEq)]
 pub struct RadioProps {
@@ -33,43 +33,25 @@ pub struct RadioProps {
 /// All YBC form components are controlled components. This means that the value of the field must
 /// be provided from a parent component, and changes to this component are propagated to the parent
 /// component via callback.
-pub struct Radio {
-    props: RadioProps,
-    link: ComponentLink<Self>,
-}
-
-impl Component for Radio {
-    type Message = String;
-    type Properties = RadioProps;
-
-    fn create(props: Self::Properties, link: ComponentLink<Self>) -> Self {
-        Self { props, link }
-    }
-
-    fn update(&mut self, msg: Self::Message) -> ShouldRender {
-        self.props.update.emit(msg);
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props.neq_assign(props)
-    }
-
-    fn view(&self) -> Html {
-        let mut classes = Classes::from("radio");
-        classes.push(&self.props.classes);
-        html! {
-            <label class=classes disabled=self.props.disabled>
-                <input
-                    type="radio"
-                    name=self.props.name.clone()
-                    value=self.props.value.clone()
-                    checked=self.props.checked_value.as_ref().map(|val| val == &self.props.value).unwrap_or(false)
-                    oninput=self.link.callback(|data: InputData| data.value)
-                    disabled=self.props.disabled
-                    />
-                {self.props.children.clone()}
-            </label>
-        }
+#[function_component(Radio)]
+pub fn radio(props: &RadioProps) -> Html {
+    let class = classes!("radio", props.classes.clone());
+    let oninput = props.update.reform(|ev: web_sys::InputEvent| {
+        let target = ev.target().expect_throw("event should have a target");
+        let input: HtmlInputElement = target.dyn_into().expect_throw("event target should be an input");
+        input.value()
+    });
+    html! {
+        <label {class} disabled={props.disabled}>
+            <input
+                type="radio"
+                name={props.name.clone()}
+                value={props.value.clone()}
+                checked={props.checked_value.as_ref().map(|val| val == &props.value).unwrap_or(false)}
+                {oninput}
+                disabled={props.disabled}
+                />
+            {props.children.clone()}
+        </label>
     }
 }

--- a/src/form/radio.rs
+++ b/src/form/radio.rs
@@ -1,4 +1,4 @@
-use wasm_bindgen::{JsCast, UnwrapThrowExt};
+use wasm_bindgen::UnwrapThrowExt;
 use web_sys::HtmlInputElement;
 use yew::prelude::*;
 
@@ -37,8 +37,7 @@ pub struct RadioProps {
 pub fn radio(props: &RadioProps) -> Html {
     let class = classes!("radio", props.classes.clone());
     let oninput = props.update.reform(|ev: web_sys::InputEvent| {
-        let target = ev.target().expect_throw("event should have a target");
-        let input: HtmlInputElement = target.dyn_into().expect_throw("event target should be an input");
+        let input: HtmlInputElement = ev.target_dyn_into().expect_throw("event target should be an input");
         input.value()
     });
     html! {

--- a/src/form/radio.rs
+++ b/src/form/radio.rs
@@ -35,7 +35,7 @@ pub struct RadioProps {
 /// component via callback.
 #[function_component(Radio)]
 pub fn radio(props: &RadioProps) -> Html {
-    let class = classes!("radio", props.classes.clone());
+    let class = classes!("radio", &props.classes);
     let oninput = props.update.reform(|ev: web_sys::InputEvent| {
         let input: HtmlInputElement = ev.target_dyn_into().expect_throw("event target should be an input");
         input.value()

--- a/src/form/radio.rs
+++ b/src/form/radio.rs
@@ -20,7 +20,7 @@ pub struct RadioProps {
     #[prop_or_default]
     pub children: Children,
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
     /// Disable this component.
     #[prop_or_default]
     pub disabled: bool,
@@ -35,7 +35,7 @@ pub struct RadioProps {
 /// component via callback.
 #[function_component(Radio)]
 pub fn radio(props: &RadioProps) -> Html {
-    let class = classes!("radio", &props.classes);
+    let class = classes!("radio", props.classes.clone());
     let oninput = props.update.reform(|ev: web_sys::InputEvent| {
         let input: HtmlInputElement = ev.target_dyn_into().expect_throw("event target should be an input");
         input.value()

--- a/src/form/select.rs
+++ b/src/form/select.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::redundant_closure_call)]
 
-use wasm_bindgen::{JsCast, UnwrapThrowExt};
+use wasm_bindgen::UnwrapThrowExt;
 use web_sys::HtmlSelectElement;
 use yew::prelude::*;
 
@@ -52,8 +52,7 @@ pub fn select(props: &SelectProps) -> Html {
         props.loading.then(|| "is-loading"),
     );
     let onchange = props.update.reform(|ev: web_sys::Event| {
-        let target = ev.target().expect_throw("event should have a target");
-        let select: HtmlSelectElement = target.dyn_into().expect_throw("event target should be a select");
+        let select: HtmlSelectElement = ev.target_dyn_into().expect_throw("event target should be a select");
         select.value()
     });
     html! {
@@ -124,8 +123,7 @@ pub fn multi_select(props: &MultiSelectProps) -> Html {
     );
     let size = props.list_size.to_string();
     let onchange = props.update.reform(|ev: web_sys::Event| {
-        let target: web_sys::EventTarget = ev.target().expect_throw("event should have a target");
-        let select: HtmlSelectElement = target.dyn_into().expect_throw("event target should be a select");
+        let select: HtmlSelectElement = ev.target_dyn_into().expect_throw("event target should be a select");
         let opts = select.selected_options();
         (0..opts.length())
             .into_iter()

--- a/src/form/select.rs
+++ b/src/form/select.rs
@@ -45,7 +45,7 @@ pub struct SelectProps {
 pub fn select(props: &SelectProps) -> Html {
     let class = classes!(
         "select",
-        props.classes.clone(),
+        &props.classes,
         props.size.as_ref().map(|size| size.to_string()),
         props.loading.then(|| "is-loading"),
     );
@@ -115,7 +115,7 @@ pub fn multi_select(props: &MultiSelectProps) -> Html {
     let class = classes!(
         "select",
         "is-multiple",
-        props.classes.clone(),
+        &props.classes,
         props.size.as_ref().map(|size| size.to_string()),
         props.loading.then(|| "is-loading"),
     );

--- a/src/form/select.rs
+++ b/src/form/select.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::redundant_closure_call)]
-
 use wasm_bindgen::UnwrapThrowExt;
 use web_sys::HtmlSelectElement;
 use yew::prelude::*;

--- a/src/form/select.rs
+++ b/src/form/select.rs
@@ -47,7 +47,7 @@ pub fn select(props: &SelectProps) -> Html {
         "select",
         &props.classes,
         props.size.as_ref().map(|size| size.to_string()),
-        props.loading.then(|| "is-loading"),
+        props.loading.then_some("is-loading"),
     );
     let onchange = props.update.reform(|ev: web_sys::Event| {
         let select: HtmlSelectElement = ev.target_dyn_into().expect_throw("event target should be a select");
@@ -117,7 +117,7 @@ pub fn multi_select(props: &MultiSelectProps) -> Html {
         "is-multiple",
         &props.classes,
         props.size.as_ref().map(|size| size.to_string()),
-        props.loading.then(|| "is-loading"),
+        props.loading.then_some("is-loading"),
     );
     let size = props.list_size.to_string();
     let onchange = props.update.reform(|ev: web_sys::Event| {

--- a/src/form/select.rs
+++ b/src/form/select.rs
@@ -17,7 +17,7 @@ pub struct SelectProps {
     #[prop_or_default]
     pub children: Children,
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
 
     /// The size of this component.
     #[prop_or_default]
@@ -45,7 +45,7 @@ pub struct SelectProps {
 pub fn select(props: &SelectProps) -> Html {
     let class = classes!(
         "select",
-        &props.classes,
+        props.classes.clone(),
         props.size.as_ref().map(|size| size.to_string()),
         props.loading.then_some("is-loading"),
     );
@@ -83,7 +83,7 @@ pub struct MultiSelectProps {
     #[prop_or_default]
     pub children: Children,
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
 
     /// The size of this component.
     #[prop_or_default]
@@ -115,7 +115,7 @@ pub fn multi_select(props: &MultiSelectProps) -> Html {
     let class = classes!(
         "select",
         "is-multiple",
-        &props.classes,
+        props.classes.clone(),
         props.size.as_ref().map(|size| size.to_string()),
         props.loading.then_some("is-loading"),
     );

--- a/src/form/textarea.rs
+++ b/src/form/textarea.rs
@@ -53,7 +53,7 @@ pub struct TextAreaProps {
 pub fn text_area(props: &TextAreaProps) -> Html {
     let class = classes!(
         "textarea",
-        props.classes.clone(),
+        &props.classes,
         props.size.as_ref().map(|size| size.to_string()),
         props.loading.then(|| "is-loading"),
         props.r#static.then(|| "is-static"),

--- a/src/form/textarea.rs
+++ b/src/form/textarea.rs
@@ -1,4 +1,4 @@
-use wasm_bindgen::{JsCast, UnwrapThrowExt};
+use wasm_bindgen::UnwrapThrowExt;
 use web_sys::HtmlTextAreaElement;
 use yew::prelude::*;
 
@@ -60,8 +60,7 @@ pub fn text_area(props: &TextAreaProps) -> Html {
         props.fixed_size.then(|| "has-fixed-size"),
     );
     let oninput = props.update.reform(|ev: web_sys::InputEvent| {
-        let target = ev.target().expect_throw("event should have a target");
-        let input: HtmlTextAreaElement = target.dyn_into().expect_throw("event target should be a text area");
+        let input: HtmlTextAreaElement = ev.target_dyn_into().expect_throw("event target should be a text area");
         input.value()
     });
     html! {

--- a/src/form/textarea.rs
+++ b/src/form/textarea.rs
@@ -55,9 +55,9 @@ pub fn text_area(props: &TextAreaProps) -> Html {
         "textarea",
         &props.classes,
         props.size.as_ref().map(|size| size.to_string()),
-        props.loading.then(|| "is-loading"),
-        props.r#static.then(|| "is-static"),
-        props.fixed_size.then(|| "has-fixed-size"),
+        props.loading.then_some("is-loading"),
+        props.r#static.then_some("is-static"),
+        props.fixed_size.then_some("has-fixed-size"),
     );
     let oninput = props.update.reform(|ev: web_sys::InputEvent| {
         let input: HtmlTextAreaElement = ev.target_dyn_into().expect_throw("event target should be a text area");

--- a/src/form/textarea.rs
+++ b/src/form/textarea.rs
@@ -14,7 +14,7 @@ pub struct TextAreaProps {
     pub update: Callback<String>,
 
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
     /// The placeholder value for this component.
     #[prop_or_default]
     pub placeholder: String,
@@ -53,7 +53,7 @@ pub struct TextAreaProps {
 pub fn text_area(props: &TextAreaProps) -> Html {
     let class = classes!(
         "textarea",
-        &props.classes,
+        props.classes.clone(),
         props.size.as_ref().map(|size| size.to_string()),
         props.loading.then_some("is-loading"),
         props.r#static.then_some("is-static"),

--- a/src/layout/container.rs
+++ b/src/layout/container.rs
@@ -1,5 +1,4 @@
 use yew::prelude::*;
-use yewtil::NeqAssign;
 
 #[derive(Clone, Debug, Properties, PartialEq)]
 pub struct ContainerProps {
@@ -15,36 +14,10 @@ pub struct ContainerProps {
 /// A simple container to center your content horizontally.
 ///
 /// [https://bulma.io/documentation/layout/container/](https://bulma.io/documentation/layout/container/)
-pub struct Container {
-    props: ContainerProps,
-}
-
-impl Component for Container {
-    type Message = ();
-    type Properties = ContainerProps;
-
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
-    }
-
-    fn update(&mut self, _: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props.neq_assign(props)
-    }
-
-    fn view(&self) -> Html {
-        let mut classes = Classes::from("container");
-        classes.push(&self.props.classes);
-        if self.props.fluid {
-            classes.push("is-fluid");
-        }
-        html! {
-            <div class=classes>
-                {self.props.children.clone()}
-            </div>
-        }
+#[function_component(Container)]
+pub fn container(props: &ContainerProps) -> Html {
+    let class = classes!("container", props.classes.clone(), props.fluid.then(|| "is-fluid"));
+    html! {
+        <div {class}>{props.children.clone()}</div>
     }
 }

--- a/src/layout/container.rs
+++ b/src/layout/container.rs
@@ -16,7 +16,7 @@ pub struct ContainerProps {
 /// [https://bulma.io/documentation/layout/container/](https://bulma.io/documentation/layout/container/)
 #[function_component(Container)]
 pub fn container(props: &ContainerProps) -> Html {
-    let class = classes!("container", props.classes.clone(), props.fluid.then(|| "is-fluid"));
+    let class = classes!("container", &props.classes, props.fluid.then(|| "is-fluid"));
     html! {
         <div {class}>{props.children.clone()}</div>
     }

--- a/src/layout/container.rs
+++ b/src/layout/container.rs
@@ -16,7 +16,7 @@ pub struct ContainerProps {
 /// [https://bulma.io/documentation/layout/container/](https://bulma.io/documentation/layout/container/)
 #[function_component(Container)]
 pub fn container(props: &ContainerProps) -> Html {
-    let class = classes!("container", &props.classes, props.fluid.then(|| "is-fluid"));
+    let class = classes!("container", &props.classes, props.fluid.then_some("is-fluid"));
     html! {
         <div {class}>{props.children.clone()}</div>
     }

--- a/src/layout/container.rs
+++ b/src/layout/container.rs
@@ -5,7 +5,7 @@ pub struct ContainerProps {
     #[prop_or_default]
     pub children: Children,
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
     /// Add a `32px` margin to the left and right sides of the container.
     #[prop_or_default]
     pub fluid: bool,
@@ -16,7 +16,7 @@ pub struct ContainerProps {
 /// [https://bulma.io/documentation/layout/container/](https://bulma.io/documentation/layout/container/)
 #[function_component(Container)]
 pub fn container(props: &ContainerProps) -> Html {
-    let class = classes!("container", &props.classes, props.fluid.then_some("is-fluid"));
+    let class = classes!("container", props.classes.clone(), props.fluid.then_some("is-fluid"));
     html! {
         <div {class}>{props.children.clone()}</div>
     }

--- a/src/layout/footer.rs
+++ b/src/layout/footer.rs
@@ -14,7 +14,7 @@ pub struct FooterProps {
 #[function_component(Footer)]
 pub fn footer(props: &FooterProps) -> Html {
     html! {
-        <footer class={classes!("footer", props.classes.clone())}>
+        <footer class={classes!("footer", &props.classes)}>
             {props.children.clone()}
         </footer>
     }

--- a/src/layout/footer.rs
+++ b/src/layout/footer.rs
@@ -1,5 +1,4 @@
 use yew::prelude::*;
-use yewtil::NeqAssign;
 
 #[derive(Clone, Debug, Properties, PartialEq)]
 pub struct FooterProps {
@@ -12,33 +11,11 @@ pub struct FooterProps {
 /// A simple responsive footer which can include anything.
 ///
 /// [https://bulma.io/documentation/layout/footer/](https://bulma.io/documentation/layout/footer/)
-pub struct Footer {
-    props: FooterProps,
-}
-
-impl Component for Footer {
-    type Message = ();
-    type Properties = FooterProps;
-
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
-    }
-
-    fn update(&mut self, _: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props.neq_assign(props)
-    }
-
-    fn view(&self) -> Html {
-        let mut classes = Classes::from("footer");
-        classes.push(&self.props.classes);
-        html! {
-            <footer class=classes>
-                {self.props.children.clone()}
-            </footer>
-        }
+#[function_component(Footer)]
+pub fn footer(props: &FooterProps) -> Html {
+    html! {
+        <footer class={classes!("footer", props.classes.clone())}>
+            {props.children.clone()}
+        </footer>
     }
 }

--- a/src/layout/footer.rs
+++ b/src/layout/footer.rs
@@ -5,7 +5,7 @@ pub struct FooterProps {
     #[prop_or_default]
     pub children: Children,
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
 }
 
 /// A simple responsive footer which can include anything.
@@ -14,7 +14,7 @@ pub struct FooterProps {
 #[function_component(Footer)]
 pub fn footer(props: &FooterProps) -> Html {
     html! {
-        <footer class={classes!("footer", &props.classes)}>
+        <footer class={classes!("footer", props.classes.clone())}>
             {props.children.clone()}
         </footer>
     }

--- a/src/layout/hero.rs
+++ b/src/layout/hero.rs
@@ -1,6 +1,5 @@
 use derive_more::Display;
 use yew::prelude::*;
-use yewtil::NeqAssign;
 
 #[derive(Clone, Debug, Properties, PartialEq)]
 pub struct HeroProps {
@@ -42,65 +41,38 @@ pub struct HeroProps {
 /// An imposing hero banner to showcase something.
 ///
 /// [https://bulma.io/documentation/layout/hero/](https://bulma.io/documentation/layout/hero/)
-pub struct Hero {
-    props: HeroProps,
-}
+#[function_component(Hero)]
+pub fn hero(props: &HeroProps) -> Html {
+    let class = classes!(
+        "hero",
+        props.classes.clone(),
+        props.fixed_nav.then(|| "is-fullheight-with-navbar"),
+        props.bold.then(|| "is-bold"),
+        props.size.as_ref().map(|size| size.to_string()),
+    );
 
-impl Component for Hero {
-    type Message = ();
-    type Properties = HeroProps;
+    // Build the header section.
+    let head = if let Some(head) = &props.head {
+        let class = classes!("hero-head", props.head_classes.clone());
+        html! {<div {class}>{head.clone()}</div>}
+    } else {
+        html! {}
+    };
+    // Build the footer section.
+    let foot = if let Some(foot) = &props.foot {
+        let class = classes!("hero-foot", props.foot_classes.clone());
+        html! {<div {class}>{foot.clone()}</div>}
+    } else {
+        html! {}
+    };
 
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
-    }
-
-    fn update(&mut self, _: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props.neq_assign(props)
-    }
-
-    fn view(&self) -> Html {
-        let mut classes = Classes::from("hero");
-        classes.push(&self.props.classes);
-        if self.props.fixed_nav {
-            classes.push("is-fullheight-with-navbar");
-        }
-        if self.props.bold {
-            classes.push("is-bold");
-        }
-        if let Some(size) = &self.props.size {
-            classes.push(&size.to_string());
-        }
-
-        // Build the header section.
-        let head = if let Some(head) = &self.props.head {
-            let mut classes = Classes::from("hero-head");
-            classes.push(&self.props.head_classes);
-            html! {<div class=classes>{head.clone()}</div>}
-        } else {
-            html! {}
-        };
-        // Build the footer section.
-        let foot = if let Some(foot) = &self.props.foot {
-            let mut classes = Classes::from("hero-foot");
-            classes.push(&self.props.foot_classes);
-            html! {<div class=classes>{foot.clone()}</div>}
-        } else {
-            html! {}
-        };
-
-        let mut body_classes = Classes::from("hero-body");
-        body_classes.push(&self.props.body_classes);
-        html! {
-            <section class=classes>
-                {head}
-                <div class=body_classes>{self.props.body.clone()}</div>
-                {foot}
-            </section>
-        }
+    let body_classes = classes!("hero-body", props.body_classes.clone());
+    html! {
+        <section {class}>
+            {head}
+            <div class={body_classes}>{props.body.clone()}</div>
+            {foot}
+        </section>
     }
 }
 

--- a/src/layout/hero.rs
+++ b/src/layout/hero.rs
@@ -45,7 +45,7 @@ pub struct HeroProps {
 pub fn hero(props: &HeroProps) -> Html {
     let class = classes!(
         "hero",
-        props.classes.clone(),
+        &props.classes,
         props.fixed_nav.then(|| "is-fullheight-with-navbar"),
         props.bold.then(|| "is-bold"),
         props.size.as_ref().map(|size| size.to_string()),

--- a/src/layout/hero.rs
+++ b/src/layout/hero.rs
@@ -46,8 +46,8 @@ pub fn hero(props: &HeroProps) -> Html {
     let class = classes!(
         "hero",
         &props.classes,
-        props.fixed_nav.then(|| "is-fullheight-with-navbar"),
-        props.bold.then(|| "is-bold"),
+        props.fixed_nav.then_some("is-fullheight-with-navbar"),
+        props.bold.then_some("is-bold"),
         props.size.as_ref().map(|size| size.to_string()),
     );
 
@@ -79,7 +79,7 @@ pub fn hero(props: &HeroProps) -> Html {
 /// The 4 sizes available for heroes.
 ///
 /// [https://bulma.io/documentation/layout/hero/#sizes](https://bulma.io/documentation/layout/hero/#sizes)
-#[derive(Clone, Debug, Display, PartialEq)]
+#[derive(Clone, Debug, Display, PartialEq, Eq)]
 #[display(fmt = "is-{}")]
 pub enum HeroSize {
     #[display(fmt = "medium")]

--- a/src/layout/hero.rs
+++ b/src/layout/hero.rs
@@ -5,24 +5,24 @@ use yew::prelude::*;
 pub struct HeroProps {
     /// Extra classes for the hero container.
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
     /// The contents of the hero-head section.
     #[prop_or_default]
     pub head: Option<Html>,
     /// Optional classes to add to the hero-head container.
     #[prop_or_default]
-    pub head_classes: Option<Classes>,
+    pub head_classes: Classes,
     /// The contents of the hero-body section.
     pub body: Html,
     /// Optional classes to add to the hero-body container.
     #[prop_or_default]
-    pub body_classes: Option<Classes>,
+    pub body_classes: Classes,
     /// The contents of the hero-foot section.
     #[prop_or_default]
     pub foot: Option<Html>,
     /// Optional classes to add to the hero-foot container.
     #[prop_or_default]
-    pub foot_classes: Option<Classes>,
+    pub foot_classes: Classes,
     /// If you are using a [fixed navbar](https://bulma.io/documentation/components/navbar/#fixed-navbar),
     /// you can use the `fixed_nav=true` modifier on the hero for it to occupy the viewport height minus
     /// the navbar height.
@@ -45,7 +45,7 @@ pub struct HeroProps {
 pub fn hero(props: &HeroProps) -> Html {
     let class = classes!(
         "hero",
-        &props.classes,
+        props.classes.clone(),
         props.fixed_nav.then_some("is-fullheight-with-navbar"),
         props.bold.then_some("is-bold"),
         props.size.as_ref().map(|size| size.to_string()),

--- a/src/layout/level.rs
+++ b/src/layout/level.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::redundant_closure_call)]
-
 use yew::prelude::*;
 
 #[derive(Clone, Debug, Properties, PartialEq)]

--- a/src/layout/level.rs
+++ b/src/layout/level.rs
@@ -1,7 +1,6 @@
 #![allow(clippy::redundant_closure_call)]
 
 use yew::prelude::*;
-use yewtil::NeqAssign;
 
 #[derive(Clone, Debug, Properties, PartialEq)]
 pub struct LevelProps {
@@ -17,34 +16,13 @@ pub struct LevelProps {
 /// A multi-purpose horizontal level, which can contain almost any other element.
 ///
 /// [https://bulma.io/documentation/layout/level/](https://bulma.io/documentation/layout/level/)
-pub struct Level {
-    props: LevelProps,
-}
-
-impl Component for Level {
-    type Message = ();
-    type Properties = LevelProps;
-
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
-    }
-
-    fn update(&mut self, _: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props.neq_assign(props)
-    }
-
-    fn view(&self) -> Html {
-        let mut classes = Classes::from("level");
-        classes.push(&self.props.classes);
-        html! {
-            <@{self.props.tag.clone()} class=classes>
-                {self.props.children.clone()}
-            </@>
-        }
+#[function_component(Level)]
+pub fn level(props: &LevelProps) -> Html {
+    let class = classes!("level", props.classes.clone());
+    html! {
+        <@{props.tag.clone()} {class}>
+            {props.children.clone()}
+        </@>
     }
 }
 
@@ -65,34 +43,13 @@ pub struct LevelLeftProps {
 /// A container for level elements to be grouped to the left of the container.
 ///
 /// [https://bulma.io/documentation/layout/level/](https://bulma.io/documentation/layout/level/)
-pub struct LevelLeft {
-    props: LevelLeftProps,
-}
-
-impl Component for LevelLeft {
-    type Message = ();
-    type Properties = LevelLeftProps;
-
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
-    }
-
-    fn update(&mut self, _: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props.neq_assign(props)
-    }
-
-    fn view(&self) -> Html {
-        let mut classes = Classes::from("level-left");
-        classes.push(&self.props.classes);
-        html! {
-            <@{self.props.tag.clone()} class=classes>
-                {self.props.children.clone()}
-            </@>
-        }
+#[function_component(LevelLeft)]
+pub fn level_left(props: &LevelLeftProps) -> Html {
+    let class = classes!("level-left", props.classes.clone());
+    html! {
+        <@{props.tag.clone()} {class}>
+            {props.children.clone()}
+        </@>
     }
 }
 
@@ -113,34 +70,13 @@ pub struct LevelRightProps {
 /// A container for level elements to be grouped to the right of the container.
 ///
 /// [https://bulma.io/documentation/layout/level/](https://bulma.io/documentation/layout/level/)
-pub struct LevelRight {
-    props: LevelRightProps,
-}
-
-impl Component for LevelRight {
-    type Message = ();
-    type Properties = LevelRightProps;
-
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
-    }
-
-    fn update(&mut self, _: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props.neq_assign(props)
-    }
-
-    fn view(&self) -> Html {
-        let mut classes = Classes::from("level-right");
-        classes.push(&self.props.classes);
-        html! {
-            <@{self.props.tag.clone()} class=classes>
-                {self.props.children.clone()}
-            </@>
-        }
+#[function_component(LevelRight)]
+pub fn level_right(props: &LevelRightProps) -> Html {
+    let class = classes!("level-right", props.classes.clone());
+    html! {
+        <@{props.tag.clone()} {class}>
+            {props.children.clone()}
+        </@>
     }
 }
 
@@ -161,33 +97,12 @@ pub struct LevelItemProps {
 /// An individual element of a level container.
 ///
 /// [https://bulma.io/documentation/layout/level/](https://bulma.io/documentation/layout/level/)
-pub struct LevelItem {
-    props: LevelItemProps,
-}
-
-impl Component for LevelItem {
-    type Message = ();
-    type Properties = LevelItemProps;
-
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
-    }
-
-    fn update(&mut self, _: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props.neq_assign(props)
-    }
-
-    fn view(&self) -> Html {
-        let mut classes = Classes::from("level-item");
-        classes.push(&self.props.classes);
-        html! {
-            <@{self.props.tag.clone()} class=classes>
-                {self.props.children.clone()}
-            </@>
-        }
+#[function_component(LevelItem)]
+pub fn level_item(props: &LevelItemProps) -> Html {
+    let class = classes!("level-item", props.classes.clone());
+    html! {
+        <@{props.tag.clone()} {class}>
+            {props.children.clone()}
+        </@>
     }
 }

--- a/src/layout/level.rs
+++ b/src/layout/level.rs
@@ -16,7 +16,7 @@ pub struct LevelProps {
 /// [https://bulma.io/documentation/layout/level/](https://bulma.io/documentation/layout/level/)
 #[function_component(Level)]
 pub fn level(props: &LevelProps) -> Html {
-    let class = classes!("level", props.classes.clone());
+    let class = classes!("level", &props.classes);
     html! {
         <@{props.tag.clone()} {class}>
             {props.children.clone()}
@@ -43,7 +43,7 @@ pub struct LevelLeftProps {
 /// [https://bulma.io/documentation/layout/level/](https://bulma.io/documentation/layout/level/)
 #[function_component(LevelLeft)]
 pub fn level_left(props: &LevelLeftProps) -> Html {
-    let class = classes!("level-left", props.classes.clone());
+    let class = classes!("level-left", &props.classes);
     html! {
         <@{props.tag.clone()} {class}>
             {props.children.clone()}
@@ -70,7 +70,7 @@ pub struct LevelRightProps {
 /// [https://bulma.io/documentation/layout/level/](https://bulma.io/documentation/layout/level/)
 #[function_component(LevelRight)]
 pub fn level_right(props: &LevelRightProps) -> Html {
-    let class = classes!("level-right", props.classes.clone());
+    let class = classes!("level-right", &props.classes);
     html! {
         <@{props.tag.clone()} {class}>
             {props.children.clone()}
@@ -97,7 +97,7 @@ pub struct LevelItemProps {
 /// [https://bulma.io/documentation/layout/level/](https://bulma.io/documentation/layout/level/)
 #[function_component(LevelItem)]
 pub fn level_item(props: &LevelItemProps) -> Html {
-    let class = classes!("level-item", props.classes.clone());
+    let class = classes!("level-item", &props.classes);
     html! {
         <@{props.tag.clone()} {class}>
             {props.children.clone()}

--- a/src/layout/level.rs
+++ b/src/layout/level.rs
@@ -5,7 +5,7 @@ pub struct LevelProps {
     #[prop_or_default]
     pub children: Children,
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
     /// The HTML tag to use for this component.
     #[prop_or_else(|| "nav".into())]
     pub tag: String,
@@ -16,7 +16,7 @@ pub struct LevelProps {
 /// [https://bulma.io/documentation/layout/level/](https://bulma.io/documentation/layout/level/)
 #[function_component(Level)]
 pub fn level(props: &LevelProps) -> Html {
-    let class = classes!("level", &props.classes);
+    let class = classes!("level", props.classes.clone());
     html! {
         <@{props.tag.clone()} {class}>
             {props.children.clone()}
@@ -32,7 +32,7 @@ pub struct LevelLeftProps {
     #[prop_or_default]
     pub children: Children,
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
     /// The HTML tag to use for this component.
     #[prop_or_else(|| "div".into())]
     pub tag: String,
@@ -43,7 +43,7 @@ pub struct LevelLeftProps {
 /// [https://bulma.io/documentation/layout/level/](https://bulma.io/documentation/layout/level/)
 #[function_component(LevelLeft)]
 pub fn level_left(props: &LevelLeftProps) -> Html {
-    let class = classes!("level-left", &props.classes);
+    let class = classes!("level-left", props.classes.clone());
     html! {
         <@{props.tag.clone()} {class}>
             {props.children.clone()}
@@ -59,7 +59,7 @@ pub struct LevelRightProps {
     #[prop_or_default]
     pub children: Children,
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
     /// The HTML tag to use for this component.
     #[prop_or_else(|| "div".into())]
     pub tag: String,
@@ -70,7 +70,7 @@ pub struct LevelRightProps {
 /// [https://bulma.io/documentation/layout/level/](https://bulma.io/documentation/layout/level/)
 #[function_component(LevelRight)]
 pub fn level_right(props: &LevelRightProps) -> Html {
-    let class = classes!("level-right", &props.classes);
+    let class = classes!("level-right", props.classes.clone());
     html! {
         <@{props.tag.clone()} {class}>
             {props.children.clone()}
@@ -86,7 +86,7 @@ pub struct LevelItemProps {
     #[prop_or_default]
     pub children: Children,
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
     /// The HTML tag to use for this component.
     #[prop_or_else(|| "div".into())]
     pub tag: String,
@@ -97,7 +97,7 @@ pub struct LevelItemProps {
 /// [https://bulma.io/documentation/layout/level/](https://bulma.io/documentation/layout/level/)
 #[function_component(LevelItem)]
 pub fn level_item(props: &LevelItemProps) -> Html {
-    let class = classes!("level-item", &props.classes);
+    let class = classes!("level-item", props.classes.clone());
     html! {
         <@{props.tag.clone()} {class}>
             {props.children.clone()}

--- a/src/layout/media.rs
+++ b/src/layout/media.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::redundant_closure_call)]
-
 use yew::prelude::*;
 
 #[derive(Clone, Debug, Properties, PartialEq)]

--- a/src/layout/media.rs
+++ b/src/layout/media.rs
@@ -1,7 +1,6 @@
 #![allow(clippy::redundant_closure_call)]
 
 use yew::prelude::*;
-use yewtil::NeqAssign;
 
 #[derive(Clone, Debug, Properties, PartialEq)]
 pub struct MediaProps {
@@ -17,34 +16,13 @@ pub struct MediaProps {
 /// A UI element for repeatable and nestable content.
 ///
 /// [https://bulma.io/documentation/layout/media-object/](https://bulma.io/documentation/layout/media-object/)
-pub struct Media {
-    props: MediaProps,
-}
-
-impl Component for Media {
-    type Message = ();
-    type Properties = MediaProps;
-
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
-    }
-
-    fn update(&mut self, _: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props.neq_assign(props)
-    }
-
-    fn view(&self) -> Html {
-        let mut classes = Classes::from("media");
-        classes.push(&self.props.classes);
-        html! {
-            <@{self.props.tag.clone()} class=classes>
-                {self.props.children.clone()}
-            </@>
-        }
+#[function_component(Media)]
+pub fn media(props: &MediaProps) -> Html {
+    let class = classes!("media", props.classes.clone());
+    html! {
+        <@{props.tag.clone()} {class}>
+            {props.children.clone()}
+        </@>
     }
 }
 
@@ -65,34 +43,13 @@ pub struct MediaLeftProps {
 /// Elements to be grouped to the left of the media container.
 ///
 /// [https://bulma.io/documentation/layout/media-object/](https://bulma.io/documentation/layout/media-object/)
-pub struct MediaLeft {
-    props: MediaLeftProps,
-}
-
-impl Component for MediaLeft {
-    type Message = ();
-    type Properties = MediaLeftProps;
-
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
-    }
-
-    fn update(&mut self, _: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props.neq_assign(props)
-    }
-
-    fn view(&self) -> Html {
-        let mut classes = Classes::from("media-left");
-        classes.push(&self.props.classes);
-        html! {
-            <@{self.props.tag.clone()} class=classes>
-                {self.props.children.clone()}
-            </@>
-        }
+#[function_component(MediaLeft)]
+pub fn media_left(props: &MediaLeftProps) -> Html {
+    let class = classes!("media-left", props.classes.clone());
+    html! {
+        <@{props.tag.clone()} {class}>
+            {props.children.clone()}
+        </@>
     }
 }
 
@@ -113,34 +70,13 @@ pub struct MediaRightProps {
 /// Elements to be grouped to the right of the media container.
 ///
 /// [https://bulma.io/documentation/layout/media-object/](https://bulma.io/documentation/layout/media-object/)
-pub struct MediaRight {
-    props: MediaRightProps,
-}
-
-impl Component for MediaRight {
-    type Message = ();
-    type Properties = MediaRightProps;
-
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
-    }
-
-    fn update(&mut self, _: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props.neq_assign(props)
-    }
-
-    fn view(&self) -> Html {
-        let mut classes = Classes::from("media-right");
-        classes.push(&self.props.classes);
-        html! {
-            <@{self.props.tag.clone()} class=classes>
-                {self.props.children.clone()}
-            </@>
-        }
+#[function_component(MediaRight)]
+pub fn media_right(props: &MediaRightProps) -> Html {
+    let class = classes!("media-right", props.classes.clone());
+    html! {
+        <@{props.tag.clone()} {class}>
+            {props.children.clone()}
+        </@>
     }
 }
 
@@ -161,33 +97,12 @@ pub struct MediaContentProps {
 /// Elements to be grouped as the center body of the media container.
 ///
 /// [https://bulma.io/documentation/layout/media-object/](https://bulma.io/documentation/layout/media-object/)
-pub struct MediaContent {
-    props: MediaContentProps,
-}
-
-impl Component for MediaContent {
-    type Message = ();
-    type Properties = MediaContentProps;
-
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
-    }
-
-    fn update(&mut self, _: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props.neq_assign(props)
-    }
-
-    fn view(&self) -> Html {
-        let mut classes = Classes::from("media-content");
-        classes.push(&self.props.classes);
-        html! {
-            <@{self.props.tag.clone()} class=classes>
-                {self.props.children.clone()}
-            </@>
-        }
+#[function_component(MediaContent)]
+pub fn media_content(props: &MediaContentProps) -> Html {
+    let class = classes!("media-content", props.classes.clone());
+    html! {
+        <@{props.tag.clone()} {class}>
+            {props.children.clone()}
+        </@>
     }
 }

--- a/src/layout/media.rs
+++ b/src/layout/media.rs
@@ -16,7 +16,7 @@ pub struct MediaProps {
 /// [https://bulma.io/documentation/layout/media-object/](https://bulma.io/documentation/layout/media-object/)
 #[function_component(Media)]
 pub fn media(props: &MediaProps) -> Html {
-    let class = classes!("media", props.classes.clone());
+    let class = classes!("media", &props.classes);
     html! {
         <@{props.tag.clone()} {class}>
             {props.children.clone()}
@@ -43,7 +43,7 @@ pub struct MediaLeftProps {
 /// [https://bulma.io/documentation/layout/media-object/](https://bulma.io/documentation/layout/media-object/)
 #[function_component(MediaLeft)]
 pub fn media_left(props: &MediaLeftProps) -> Html {
-    let class = classes!("media-left", props.classes.clone());
+    let class = classes!("media-left", &props.classes);
     html! {
         <@{props.tag.clone()} {class}>
             {props.children.clone()}
@@ -70,7 +70,7 @@ pub struct MediaRightProps {
 /// [https://bulma.io/documentation/layout/media-object/](https://bulma.io/documentation/layout/media-object/)
 #[function_component(MediaRight)]
 pub fn media_right(props: &MediaRightProps) -> Html {
-    let class = classes!("media-right", props.classes.clone());
+    let class = classes!("media-right", &props.classes);
     html! {
         <@{props.tag.clone()} {class}>
             {props.children.clone()}
@@ -97,7 +97,7 @@ pub struct MediaContentProps {
 /// [https://bulma.io/documentation/layout/media-object/](https://bulma.io/documentation/layout/media-object/)
 #[function_component(MediaContent)]
 pub fn media_content(props: &MediaContentProps) -> Html {
-    let class = classes!("media-content", props.classes.clone());
+    let class = classes!("media-content", &props.classes);
     html! {
         <@{props.tag.clone()} {class}>
             {props.children.clone()}

--- a/src/layout/media.rs
+++ b/src/layout/media.rs
@@ -5,7 +5,7 @@ pub struct MediaProps {
     #[prop_or_default]
     pub children: Children,
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
     /// The HTML tag to use for this component.
     #[prop_or_else(|| "div".into())]
     pub tag: String,
@@ -16,7 +16,7 @@ pub struct MediaProps {
 /// [https://bulma.io/documentation/layout/media-object/](https://bulma.io/documentation/layout/media-object/)
 #[function_component(Media)]
 pub fn media(props: &MediaProps) -> Html {
-    let class = classes!("media", &props.classes);
+    let class = classes!("media", props.classes.clone());
     html! {
         <@{props.tag.clone()} {class}>
             {props.children.clone()}
@@ -32,7 +32,7 @@ pub struct MediaLeftProps {
     #[prop_or_default]
     pub children: Children,
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
     /// The HTML tag to use for this component.
     #[prop_or_else(|| "div".into())]
     pub tag: String,
@@ -43,7 +43,7 @@ pub struct MediaLeftProps {
 /// [https://bulma.io/documentation/layout/media-object/](https://bulma.io/documentation/layout/media-object/)
 #[function_component(MediaLeft)]
 pub fn media_left(props: &MediaLeftProps) -> Html {
-    let class = classes!("media-left", &props.classes);
+    let class = classes!("media-left", props.classes.clone());
     html! {
         <@{props.tag.clone()} {class}>
             {props.children.clone()}
@@ -59,7 +59,7 @@ pub struct MediaRightProps {
     #[prop_or_default]
     pub children: Children,
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
     /// The HTML tag to use for this component.
     #[prop_or_else(|| "div".into())]
     pub tag: String,
@@ -70,7 +70,7 @@ pub struct MediaRightProps {
 /// [https://bulma.io/documentation/layout/media-object/](https://bulma.io/documentation/layout/media-object/)
 #[function_component(MediaRight)]
 pub fn media_right(props: &MediaRightProps) -> Html {
-    let class = classes!("media-right", &props.classes);
+    let class = classes!("media-right", props.classes.clone());
     html! {
         <@{props.tag.clone()} {class}>
             {props.children.clone()}
@@ -86,7 +86,7 @@ pub struct MediaContentProps {
     #[prop_or_default]
     pub children: Children,
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
     /// The HTML tag to use for this component.
     #[prop_or_else(|| "div".into())]
     pub tag: String,
@@ -97,7 +97,7 @@ pub struct MediaContentProps {
 /// [https://bulma.io/documentation/layout/media-object/](https://bulma.io/documentation/layout/media-object/)
 #[function_component(MediaContent)]
 pub fn media_content(props: &MediaContentProps) -> Html {
-    let class = classes!("media-content", &props.classes);
+    let class = classes!("media-content", props.classes.clone());
     html! {
         <@{props.tag.clone()} {class}>
             {props.children.clone()}

--- a/src/layout/section.rs
+++ b/src/layout/section.rs
@@ -1,6 +1,5 @@
 use derive_more::Display;
 use yew::prelude::*;
-use yewtil::NeqAssign;
 
 #[derive(Clone, Debug, Properties, PartialEq)]
 pub struct SectionProps {
@@ -16,37 +15,14 @@ pub struct SectionProps {
 /// A simple container to divide your page into sections.
 ///
 /// [https://bulma.io/documentation/layout/section/](https://bulma.io/documentation/layout/section/)
-pub struct Section {
-    props: SectionProps,
-}
-
-impl Component for Section {
-    type Message = ();
-    type Properties = SectionProps;
-
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
-    }
-
-    fn update(&mut self, _: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props.neq_assign(props)
-    }
-
-    fn view(&self) -> Html {
-        let mut classes = Classes::from("section");
-        classes.push(&self.props.classes);
-        if let Some(size) = &self.props.size {
-            classes.push(&size.to_string());
-        }
-        html! {
-            <section class=classes>
-                {self.props.children.clone()}
-            </section>
-        }
+#[function_component(Section)]
+pub fn section(props: &SectionProps) -> Html {
+    let size = props.size.as_ref().map(|size| size.to_string());
+    let class = classes!("section", props.classes.clone(), size);
+    html! {
+        <section {class}>
+            {props.children.clone()}
+        </section>
     }
 }
 

--- a/src/layout/section.rs
+++ b/src/layout/section.rs
@@ -18,9 +18,8 @@ pub struct SectionProps {
 #[function_component(Section)]
 pub fn section(props: &SectionProps) -> Html {
     let size = props.size.as_ref().map(|size| size.to_string());
-    let class = classes!("section", props.classes.clone(), size);
     html! {
-        <section {class}>
+        <section class={classes!("section", &props.classes, size)}>
             {props.children.clone()}
         </section>
     }

--- a/src/layout/section.rs
+++ b/src/layout/section.rs
@@ -6,7 +6,7 @@ pub struct SectionProps {
     #[prop_or_default]
     pub children: Children,
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
     /// A size modifier to control spacing.
     #[prop_or_default]
     pub size: Option<SectionSize>,
@@ -19,7 +19,7 @@ pub struct SectionProps {
 pub fn section(props: &SectionProps) -> Html {
     let size = props.size.as_ref().map(|size| size.to_string());
     html! {
-        <section class={classes!("section", &props.classes, size)}>
+        <section class={classes!("section", props.classes.clone(), size)}>
             {props.children.clone()}
         </section>
     }

--- a/src/layout/section.rs
+++ b/src/layout/section.rs
@@ -28,7 +28,7 @@ pub fn section(props: &SectionProps) -> Html {
 /// The 2 sizes available for sections, which controls spacing.
 ///
 /// [https://bulma.io/documentation/layout/section/](https://bulma.io/documentation/layout/section/)
-#[derive(Clone, Debug, Display, PartialEq)]
+#[derive(Clone, Debug, Display, PartialEq, Eq)]
 #[display(fmt = "is-{}")]
 pub enum SectionSize {
     #[display(fmt = "medium")]

--- a/src/layout/tile.rs
+++ b/src/layout/tile.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::redundant_closure_call)]
-
 use derive_more::Display;
 use yew::prelude::*;
 

--- a/src/layout/tile.rs
+++ b/src/layout/tile.rs
@@ -2,7 +2,6 @@
 
 use derive_more::Display;
 use yew::prelude::*;
-use yewtil::NeqAssign;
 
 #[derive(Clone, Debug, Properties, PartialEq)]
 pub struct TileProps {
@@ -33,43 +32,15 @@ pub struct TileProps {
 /// A single tile element to build 2-dimensional whatever-you-like grids.
 ///
 /// [https://bulma.io/documentation/layout/tiles/](https://bulma.io/documentation/layout/tiles/)
-pub struct Tile {
-    props: TileProps,
-}
-
-impl Component for Tile {
-    type Message = ();
-    type Properties = TileProps;
-
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
-    }
-
-    fn update(&mut self, _: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props.neq_assign(props)
-    }
-
-    fn view(&self) -> Html {
-        let mut classes = Classes::from("tile");
-        classes.push(&self.props.classes);
-        if let Some(ctx) = &self.props.ctx {
-            classes.push(&ctx.to_string());
-        }
-        if self.props.vertical {
-            classes.push("is-vertical");
-        }
-        if let Some(size) = &self.props.size {
-            classes.push(&size.to_string());
-        }
-        html! {
-            <@{self.props.tag.clone()} class=classes>
-                {self.props.children.clone()}
-            </@>
-        }
+#[function_component(Tile)]
+pub fn tile(props: &TileProps) -> Html {
+    let ctx = props.ctx.as_ref().map(|ctx| ctx.to_string());
+    let size = props.size.as_ref().map(|size| size.to_string());
+    let class = classes!("tile", props.classes.clone(), ctx, props.vertical.then(|| "is-vertical"), size);
+    html! {
+        <@{props.tag.clone()} {class}>
+            {props.children.clone()}
+        </@>
     }
 }
 

--- a/src/layout/tile.rs
+++ b/src/layout/tile.rs
@@ -34,7 +34,7 @@ pub struct TileProps {
 pub fn tile(props: &TileProps) -> Html {
     let ctx = props.ctx.as_ref().map(|ctx| ctx.to_string());
     let size = props.size.as_ref().map(|size| size.to_string());
-    let class = classes!("tile", props.classes.clone(), ctx, props.vertical.then(|| "is-vertical"), size);
+    let class = classes!("tile", &props.classes, ctx, props.vertical.then(|| "is-vertical"), size);
     html! {
         <@{props.tag.clone()} {class}>
             {props.children.clone()}

--- a/src/layout/tile.rs
+++ b/src/layout/tile.rs
@@ -34,7 +34,7 @@ pub struct TileProps {
 pub fn tile(props: &TileProps) -> Html {
     let ctx = props.ctx.as_ref().map(|ctx| ctx.to_string());
     let size = props.size.as_ref().map(|size| size.to_string());
-    let class = classes!("tile", &props.classes, ctx, props.vertical.then(|| "is-vertical"), size);
+    let class = classes!("tile", &props.classes, ctx, props.vertical.then_some("is-vertical"), size);
     html! {
         <@{props.tag.clone()} {class}>
             {props.children.clone()}
@@ -45,7 +45,7 @@ pub fn tile(props: &TileProps) -> Html {
 /// Tile context modifiers.
 ///
 /// https://bulma.io/documentation/layout/tiles/#modifiers
-#[derive(Clone, Debug, Display, PartialEq)]
+#[derive(Clone, Debug, Display, PartialEq, Eq)]
 #[display(fmt = "is-{}")]
 pub enum TileCtx {
     #[display(fmt = "ancestor")]
@@ -59,7 +59,7 @@ pub enum TileCtx {
 /// Tile size modifiers.
 ///
 /// https://bulma.io/documentation/layout/tiles/#modifiers
-#[derive(Clone, Debug, Display, PartialEq)]
+#[derive(Clone, Debug, Display, PartialEq, Eq)]
 #[display(fmt = "is-{}")]
 pub enum TileSize {
     #[display(fmt = "1")]

--- a/src/layout/tile.rs
+++ b/src/layout/tile.rs
@@ -6,7 +6,7 @@ pub struct TileProps {
     #[prop_or_default]
     pub children: Children,
     #[prop_or_default]
-    pub classes: Option<Classes>,
+    pub classes: Classes,
     /// The HTML tag to use for this component.
     #[prop_or_else(|| "div".into())]
     pub tag: String,
@@ -34,7 +34,7 @@ pub struct TileProps {
 pub fn tile(props: &TileProps) -> Html {
     let ctx = props.ctx.as_ref().map(|ctx| ctx.to_string());
     let size = props.size.as_ref().map(|size| size.to_string());
-    let class = classes!("tile", &props.classes, ctx, props.vertical.then_some("is-vertical"), size);
+    let class = classes!("tile", props.classes.clone(), ctx, props.vertical.then_some("is-vertical"), size);
     html! {
         <@{props.tag.clone()} {class}>
             {props.children.clone()}


### PR DESCRIPTION
I'm working on updating the whole codebase to support yew 0.19, while also making the majority of components function components (because simple wrappers like ybc does are a really good usecase for function components). I know that this is close to a complete rewrite, but in my opinion, it's for the best of this crate. I'm open to suggestions for changes.

Currently this is a draft because
1. I'm not using yew 0.19 in my projects yet, so I can't test it yet (I will be able to soon enough though)
2. Yew 0.19 has not been released yet, and I don't want to commit a git dependency to the ybc repo. This is also why I didn't tag a release yet. However, if someone has way too much time on their hands, they could already attempt to review it.
3. There are still open questions:
    - [ ] Yew's input event helpers were deprecated with this release, and there's now multiple ways of handling these; I went for the raw wasm-bindgen variant in the initial draft, which meant adding just one dependency, but [we might want to consider other alternatives](https://yew.rs/docs/concepts/html/events#typed-event-target). Affected components: Everything that uses InputData or ChangeData, which means `File`, `Input`, `Radio`, `Select` and `TextArea`.
    - [ ] As the router API changed completely, I've barely touched the router components for now; I didn't make them function components and I also didn't change their behavior, they only wrap the newer `yew_router::components::Link` component now. The `RouterButton` component doesn't exist in yew_router anymore, so we might want to a) deprecate the ybc `RouterButton` or b) implement it differently by taking inspiration from `Link`; however we could also consider removing the direct yew-router support completely. Affected is everything gated by the router feature, but most importantly RouterButton.
    - [x] ~I've replaced almost all places where a `Classes` instance was created with a `classes!` macro invocation. I don't know why it wasn't done like that before and would be happy to change it back if there's a good reason. (I've only avoided it where the logic was complex and I was too tired to think about it reasonably.)~ Looks like this is not gonna be an issue! I might still look into making some macro invocations even shorter though.
    - [x] ~Aggressively converting most components to function components might also not be wanted by the maintainer(s) here, so I'm open to changing some of them back. I've only avoided it for components that store state or connect to agents for now; we could go all the way and make those fn components as well, or we could roll back, I don't really care. However I do think that the vast majority of components in ybc benefits hugely from being turned into a function component because most of them really are just simple wrappers.~ I don't think there's any objections to this.

