### PR TITLE
Indeterminate Progress Bar

### DIFF
--- a/src/elements/progress.rs
+++ b/src/elements/progress.rs
@@ -8,8 +8,8 @@ pub struct ProgressProps {
     #[prop_or_else(|| 1.0)]
     pub max: f32,
     /// The amount of progress which has been made.
-    #[prop_or_else(|| 0.0)]
-    pub value: f32,
+    #[prop_or_else(|| Some(0.0))]
+    pub value: Option<f32>,
 }
 
 /// A native HTML progress bar.
@@ -19,11 +19,16 @@ pub struct ProgressProps {
 pub fn progress(props: &ProgressProps) -> Html {
     let class = classes!("progress", props.classes.clone());
     let max = props.max.to_string();
-    let value = props.value.to_string();
-    let value_txt = format!("{}%", value);
-    html! {
-        <progress {class} {max} {value}>
-            {value_txt}
-        </progress>
+    if let Some(value) = props.value.as_ref() {
+        let value_txt = format!("{}%", value);
+        html! {
+            <progress {class} {max} value={value.to_string()}>
+                {value_txt}
+            </progress>
+        }
+    } else {
+        html! {
+            <progress {class} {max}></progress>
+        }
     }
 }


### PR DESCRIPTION
Makes value of Progress Bar optional.
Progress bar without a value become indeterminate.

see https://bulma.io/documentation/elements/progress/#indeterminate