### PR TITLE
Feature make character of PaginationEllipsis configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This changelog follows the patterns described here: https://keepachangelog.com/e
 Subheadings to categorize changes are `added, changed, deprecated, removed, fixed, security`.
 
 ## Unreleased
+### added
+- Configurable character of PaginationEllipsis
 
 ## 0.4.0-beta.0
 The only real change here is that YBC has been updated to Yew 0.20, which included updating only a few components.

--- a/src/components/pagination.rs
+++ b/src/components/pagination.rs
@@ -95,7 +95,8 @@ pub enum PaginationItemType {
 
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
-///
+
+/// Properties of [`PaginationEllipsis`] component.
 #[derive(Clone, Debug, Properties, PartialEq)]
 pub struct PaginationEllipsisProps {
     /// Character which will be used as ellipsis (default: `"…"`)

--- a/src/components/pagination.rs
+++ b/src/components/pagination.rs
@@ -95,13 +95,20 @@ pub enum PaginationItemType {
 
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
+///
+#[derive(Clone, Debug, Properties, PartialEq)]
+pub struct PaginationEllipsisProps {
+    /// Character which will be used as ellipsis (default: `"…"`)
+    #[prop_or_else(|| "…".into())]
+    pub character: String,
+}
 
 /// A horizontal ellipsis for pagination range separators.
 ///
 /// [https://bulma.io/documentation/components/pagination/](https://bulma.io/documentation/components/pagination/)
 #[function_component(PaginationEllipsis)]
-pub fn pagination_ellipsis() -> Html {
-    html! {<span class="pagination-ellipsis">{"&hellip;"}</span>}
+pub fn pagination_ellipsis(props: &PaginationEllipsisProps) -> Html {
+    html! {<span class="pagination-ellipsis">{&props.character}</span>}
 }
 
 //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
And set the default character to "…" instead of "&hellip;", because "&hellip;" was not displayed correctly with the latest version of yew.

Before:
![before](https://user-images.githubusercontent.com/2659336/229433403-5e8e3a92-ec09-4166-863e-68308af5f451.png)

After:
![after](https://user-images.githubusercontent.com/2659336/229433444-7fe05834-657a-4177-8e13-69fc3ef415de.png)
