### PR TITLE
Add config to navbar and textarea

### DIFF
--- a/src/components/navbar.rs
+++ b/src/components/navbar.rs
@@ -49,6 +49,9 @@ pub struct NavbarProps {
     /// Extra classes for the navbar burger.
     #[prop_or_default]
     pub navburger_classes: Classes,
+    /// Extra classes for the navbar menu.
+    #[prop_or_default]
+    pub navmenu_classes: Classes,
 }
 
 /// A responsive horizontal navbar that can support images, links, buttons, and dropdowns.
@@ -85,6 +88,8 @@ impl Component for Navbar {
 
         // navbar-menu classes
         let mut navclasses = Classes::from("navbar-menu");
+        navclasses.push(ctx.props().navmenu_classes.clone());
+
         let mut burgerclasses = Classes::from("navbar-burger");
         burgerclasses.push(ctx.props().navburger_classes.clone());
         if self.is_menu_open {

--- a/src/form/file.rs
+++ b/src/form/file.rs
@@ -74,10 +74,7 @@ pub fn file(props: &FileProps) -> Html {
     let onchange = props.update.reform(|ev: web_sys::Event| {
         let input: HtmlInputElement = ev.target_dyn_into().expect_throw("event target should be an input");
         let list = input.files().expect_throw("input should have a file list");
-        (0..list.length())
-            .into_iter()
-            .filter_map(|idx| list.item(idx))
-            .collect::<Vec<_>>()
+        (0..list.length()).filter_map(|idx| list.item(idx)).collect::<Vec<_>>()
     });
     html! {
         <div {class}>

--- a/src/form/select.rs
+++ b/src/form/select.rs
@@ -124,7 +124,6 @@ pub fn multi_select(props: &MultiSelectProps) -> Html {
         let select: HtmlSelectElement = ev.target_dyn_into().expect_throw("event target should be a select");
         let opts = select.selected_options();
         (0..opts.length())
-            .into_iter()
             .filter_map(|idx| opts.item(idx))
             .filter_map(|elem| elem.get_attribute("value").or_else(|| elem.text_content()))
             .collect::<Vec<_>>()

--- a/src/form/textarea.rs
+++ b/src/form/textarea.rs
@@ -40,6 +40,12 @@ pub struct TextAreaProps {
     /// Make this component static.
     #[prop_or_default]
     pub r#static: bool,
+    /// Extra classes for the textarea control.
+    #[prop_or_default]
+    pub control_classes: Classes,
+    /// The size of the control component.
+    #[prop_or_default]
+    pub control_size: Option<Size>,
 }
 
 /// A multiline textarea component.
@@ -55,15 +61,21 @@ pub fn text_area(props: &TextAreaProps) -> Html {
         "textarea",
         props.classes.clone(),
         props.size.as_ref().map(|size| size.to_string()),
-        props.loading.then_some("is-loading"),
         props.r#static.then_some("is-static"),
         props.fixed_size.then_some("has-fixed-size"),
+    );
+    let controlclasses = classes!(
+        "control",
+        props.control_classes.clone(),
+        props.control_size.as_ref().map(|size| size.to_string()),
+        props.loading.then_some("is-loading")
     );
     let oninput = props.update.reform(|ev: web_sys::InputEvent| {
         let input: HtmlTextAreaElement = ev.target_dyn_into().expect_throw("event target should be a text area");
         input.value()
     });
     html! {
+        <div class={controlclasses}>
         <textarea
             name={props.name.clone()}
             value={props.value.clone()}
@@ -73,6 +85,7 @@ pub fn text_area(props: &TextAreaProps) -> Html {
             placeholder={props.placeholder.clone()}
             disabled={props.disabled}
             readonly={props.readonly}
-            />
+        />
+        </div>
     }
 }


### PR DESCRIPTION
Add navmenu classes to navbar.

Wrap textarea in a sized control for `is-loading` as per: https://bulma.io/documentation/form/textarea/#states

Remove `.into_iter()` from `src/form/file.rs` and `src/form/select.rs` per clippy.

If any issues should be addressed or a different approach used please let me know.

Feel free to close this PR if it is unwanted.